### PR TITLE
Add cursor-based pagination, eslint, OIDC npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,53 @@ jobs:
         run: |
           node --check src/client.mjs
           node --check src/mcp.mjs
+          node --check src/mcpShared.mjs
           node --check src/server.mjs
+          node --check src/config.mjs
+          node --check src/pool.mjs
+          node --check src/helpers.mjs
+          node --check src/dispatch.mjs
           node --check src/index.mjs
 
+      - name: ESLint
+        run: npx eslint src/ scripts/
+
       - name: Markdown lint
-        run: npx markdownlint-cli README.md
+        run: npx markdownlint-cli2 README.md
 
       - name: Unit tests
         run: node --test --test-name-pattern="Unit Tests" test/integration.test.mjs
 
       - name: Mock tests
         run: node --test --test-name-pattern="Mock Tests" test/integration.test.mjs
+
+  publish:
+    name: Publish to npm
+    needs: ci
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - name: Build slim package
+        run: npm run pack
+      - name: Publish with provenance
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          TARBALL="bgx4k3p-huly-mcp-server-${VERSION}.tgz"
+          if [ -f "$TARBALL" ]; then
+            npm publish "$TARBALL" --access public --provenance || echo "Version already published"
+          else
+            echo "Tarball not found: $TARBALL"
+            exit 1
+          fi
+        # No NPM_TOKEN needed — uses OIDC Trusted Publishing.
+        # Configured at npmjs.com package settings → Trusted Publisher.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,36 @@
+export default [
+  {
+    files: ['src/**/*.mjs', 'scripts/**/*.mjs'],
+    languageOptions: {
+      ecmaVersion: 2025,
+      sourceType: 'module',
+      globals: {
+        process: 'readonly',
+        console: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        globalThis: 'readonly',
+        Buffer: 'readonly',
+        URL: 'readonly',
+        fetch: 'readonly',
+        Event: 'readonly',
+      }
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-undef': 'error',
+      'no-const-assign': 'error',
+      'no-dupe-keys': 'error',
+      'no-duplicate-case': 'error',
+      'no-unreachable': 'warn',
+      'eqeqeq': ['warn', 'smart'],
+      'no-var': 'error',
+      'prefer-const': ['warn', { destructuring: 'all' }],
+    }
+  },
+  {
+    ignores: ['node_modules/', '.smithery/', '*.tgz']
+  }
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,7 @@
         "huly-mcp-server": "src/index.mjs"
       },
       "devDependencies": {
-        "@smithery/cli": "^4.7.4",
-        "esbuild": "^0.27.4"
+        "eslint": "^10.1.0"
       },
       "engines": {
         "node": ">=22"
@@ -260,446 +259,111 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
       "engines": {
-        "node": ">=18"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=18"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
       "engines": {
-        "node": ">=18"
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -1280,6 +944,58 @@
         "hono": "^4"
       }
     },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1449,22 +1165,6 @@
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/@smithery/cli": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@smithery/cli/-/cli-4.7.4.tgz",
-      "integrity": "sha512-DLZqgmbykW40IP6nyj7NkQRlijbZjrjlXdMZvwNa+uZ1IP9+Rn9IVjTtXnPd5JI1IWMQrse/9cJeMi/PKzsH/g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "smithery": "dist/index.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.20.0 || ^4"
-      }
     },
     "node_modules/@tiptap/core": {
       "version": "2.27.1",
@@ -2039,11 +1739,25 @@
         "@tiptap/pm": "^2.7.0"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
@@ -2093,9 +1807,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -2103,6 +1817,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2175,6 +1899,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2213,6 +1947,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -2451,6 +2198,13 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2637,48 +2391,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
-      }
-    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2698,6 +2410,172 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2706,6 +2584,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2815,6 +2703,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2830,6 +2732,19 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -2851,6 +2766,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2914,6 +2867,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/gopd": {
@@ -3036,6 +3002,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3071,6 +3057,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3193,6 +3202,13 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -3204,6 +3220,37 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lexorank": {
       "version": "1.0.5",
@@ -3242,6 +3289,22 @@
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lru-cache": {
       "version": "11.2.7",
@@ -3349,6 +3412,22 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3387,6 +3466,13 @@
         "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -3455,12 +3541,62 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -3493,6 +3629,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -3547,6 +3693,16 @@
         "loadjs": "^4.3.0",
         "rangetouch": "^2.0.1",
         "url-polyfill": "^1.1.13"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/prosemirror-changeset": {
@@ -4163,6 +4319,19 @@
       "inBundle": true,
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -4200,6 +4369,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-polyfill": {
@@ -4284,6 +4463,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4327,6 +4516,19 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/zeed-dom": {
       "version": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bgx4k3p/huly-mcp-server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "MCP server for Huly issue tracking with stdio and Streamable HTTP transports",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "HULY_TRANSPORT=ws node --test test/integration.test.mjs && HULY_TRANSPORT=rest node --test test/integration.test.mjs",
     "test:ws": "HULY_TRANSPORT=ws node --test test/integration.test.mjs",
     "test:rest": "HULY_TRANSPORT=rest node --test test/integration.test.mjs",
+    "lint": "eslint src/ scripts/",
     "postinstall": "node scripts/patch-sdk.mjs",
     "pack": "node scripts/pack.mjs"
   },
@@ -58,5 +59,8 @@
     "@hcengineering/tags",
     "@hcengineering/task",
     "@hcengineering/tracker"
-  ]
+  ],
+  "devDependencies": {
+    "eslint": "^10.1.0"
+  }
 }

--- a/scripts/load-test.mjs
+++ b/scripts/load-test.mjs
@@ -91,8 +91,8 @@ async function main() {
 
   // Pick the operation to benchmark
   const operation = PROJECT
-    ? (c) => c.listIssues(PROJECT, null, null, null, null, 50)
-    : (c) => c.listProjects({});
+    ? (c) => c.listIssues(PROJECT, null, null, null, null, 50).then(r => r.items)
+    : (c) => c.listProjects({}).then(r => r.items);
 
   // Warm up
   await operation(client);

--- a/scripts/migrate-workspace.mjs
+++ b/scripts/migrate-workspace.mjs
@@ -73,7 +73,13 @@ async function main() {
 
   // ── Step 1: Read all issues from source ─────────────────────
   log('Reading source issues...');
-  const sourceIssues = await src.listIssues(PROJECT, null, null, null, null, 1000, true);
+  const sourceIssues = [];
+  let cursor;
+  do {
+    const page = await src.listIssues(PROJECT, null, null, null, null, 100, true, cursor);
+    sourceIssues.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor);
   ok(`Found ${sourceIssues.length} issues`);
 
   // Sort by issue number to preserve ordering

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -7,10 +7,12 @@
 import {
   PRIORITY_MAP, PRIORITY_NAMES,
   MILESTONE_STATUS_MAP, MILESTONE_STATUS_NAMES,
-  COLOR_PALETTE, resolveColor,
+  resolveColor,
   DONE_CATEGORY, LOST_CATEGORY, STATUS_CATEGORY_NAMES,
   DEFAULT_LABEL_CATEGORY, DEFAULT_LABEL_COLOR,
   PAGE_SIZE, MAX_BATCH_SIZE, AUTH_CACHE_TTL_MS, DEFAULT_MILESTONE_DAYS,
+  DEFAULT_PAGE_SIZE, DEFAULT_DETAIL_PAGE_SIZE,
+  encodeCursor, decodeCursor,
   nameMatch, strictGet, withExtra,
   toCollaboratorMarkup, fromCollaboratorMarkup,
   toMarkup, fromMarkup
@@ -785,18 +787,23 @@ export class HulyClient {
    * The SDK's findAll has a server-side page limit. If limit exceeds
    * the page size, this fetches multiple pages using createdOn cursor.
    */
+  /**
+   * Paginated findAll with cursor support.
+   * Fetches from the SDK in PAGE_SIZE batches, returns { items, nextCursor? }.
+   * @param {Object} client - SDK client
+   * @param {string} _class - Document class
+   * @param {Object} query - Query filter
+   * @param {Object} options - { limit, cursor, ...findAllOptions }
+   * @returns {{ items: Object[], nextCursor?: string }}
+   */
   async _paginatedFindAll(client, _class, query, options = {}) {
-    const limit = options.limit || PAGE_SIZE;
+    const limit = options.limit || DEFAULT_PAGE_SIZE;
+    let lastCreatedOn = options.cursor
+      ? decodeCursor(options.cursor).createdOn
+      : undefined;
 
-    // If within a single page, just fetch directly
-    if (limit <= PAGE_SIZE) {
-      return await client.findAll(_class, query, options);
-    }
-
-    // Fetch in pages using createdOn as cursor
     const allResults = [];
-    let remaining = limit;
-    let lastCreatedOn = undefined;
+    let remaining = limit + 1; // fetch one extra to detect next page
 
     while (remaining > 0) {
       const pageLimit = Math.min(remaining, PAGE_SIZE);
@@ -817,11 +824,42 @@ export class HulyClient {
       remaining -= page.length;
       lastCreatedOn = page[page.length - 1].createdOn;
 
-      // If we got less than requested, no more pages
       if (page.length < pageLimit) break;
     }
 
-    return allResults;
+    // If we got more than limit, there are more results
+    if (allResults.length > limit) {
+      const items = allResults.slice(0, limit);
+      return { items, nextCursor: encodeCursor(items[items.length - 1].createdOn) };
+    }
+
+    return { items: allResults };
+  }
+
+  /**
+   * In-memory cursor pagination for small collections fetched via findAll.
+   * Filters by cursor, sorts by createdOn desc, slices to limit.
+   * @param {Object[]} allResults - Full result set from findAll
+   * @param {Object} options - { cursor?, limit? }
+   * @returns {{ items: Object[], nextCursor?: string }}
+   */
+  _cursoredFindAll(allResults, options = {}) {
+    const { cursor, limit = DEFAULT_PAGE_SIZE } = options;
+    let items = [...allResults];
+
+    if (cursor) {
+      const { createdOn } = decodeCursor(cursor);
+      items = items.filter(r => r.createdOn < createdOn);
+    }
+
+    items.sort((a, b) => b.createdOn - a.createdOn);
+
+    if (items.length > limit) {
+      const page = items.slice(0, limit);
+      return { items: page, nextCursor: encodeCursor(page[page.length - 1].createdOn) };
+    }
+
+    return { items };
   }
 
   async _findEmployeeByName(client, name) {
@@ -921,8 +959,7 @@ export class HulyClient {
     const projects = await client.findAll(tracker.class.Project, {});
 
     if (!options.include_details) {
-      // Count issues per project efficiently using the project's own sequence counter
-      return projects.map(project => withExtra(project, {
+      const enriched = projects.map(project => withExtra(project, {
         id: project._id,
         identifier: project.identifier,
         name: project.name || project.identifier,
@@ -934,6 +971,7 @@ export class HulyClient {
         createdOn: project.createdOn,
         modifiedOn: project.modifiedOn
       }));
+      return this._cursoredFindAll(enriched, options);
     }
 
     // Detailed mode: batch fetch all related data once, then group by project
@@ -960,7 +998,7 @@ export class HulyClient {
       componentsByProject.get(c.space).push(c);
     }
 
-    return limitedProjects.map(project => {
+    const detailed = limitedProjects.map(project => {
       const projMilestones = (milestonesByProject.get(project._id) || []).map(m => ({
         name: m.label,
         status: strictGet(MILESTONE_STATUS_NAMES, m.status, 'Milestone status'),
@@ -993,6 +1031,7 @@ export class HulyClient {
         labels: projLabels
       });
     });
+    return this._cursoredFindAll(detailed, options);
   }
 
   /**
@@ -1067,9 +1106,9 @@ export class HulyClient {
    * @param {number} [limit=500] - Maximum number of issues
    * @returns {Promise<Object[]>}
    */
-  async listIssues(project, status, priority, label, milestone, limit, include_details = false) {
+  async listIssues(project, status, priority, label, milestone, limit, include_details = false, cursor) {
     if (limit === undefined || limit === null) {
-      limit = include_details ? 50 : 500;
+      limit = include_details ? DEFAULT_DETAIL_PAGE_SIZE : DEFAULT_PAGE_SIZE;
     }
     const client = await this._getClient();
 
@@ -1112,10 +1151,11 @@ export class HulyClient {
       }
     }
 
-    let issues = await this._paginatedFindAll(client, tracker.class.Issue, query, {
-      limit,
-      sort: { modifiedOn: -1 }
+    const fetchResult = await this._paginatedFindAll(client, tracker.class.Issue, query, {
+      limit, cursor
     });
+    const issues = fetchResult.items;
+    const nextCursor = fetchResult.nextCursor;
 
     let labelFilter = null;
     if (label) {
@@ -1267,7 +1307,9 @@ export class HulyClient {
       result.push(withExtra(issue, entry));
     }
 
-    return result;
+    const response = { items: result };
+    if (nextCursor) response.nextCursor = nextCursor;
+    return response;
   }
 
   /**
@@ -1650,20 +1692,21 @@ export class HulyClient {
    * List all available labels for issues.
    * @returns {Promise<Object[]>}
    */
-  async listLabels() {
+  async listLabels(options = {}) {
     const client = await this._getClient();
 
     const tagElements = await client.findAll(tags.class.TagElement, {
       targetClass: tracker.class.Issue
     });
 
-    return tagElements.map(t => withExtra(t, {
+    const enriched = tagElements.map(t => withExtra(t, {
       id: t._id,
       name: t.title,
       description: t.description || '',
       color: t.color ? `#${t.color.toString(16).padStart(6, '0')}` : null,
       category: t.category || null
     }));
+    return this._cursoredFindAll(enriched, options);
   }
 
   /**
@@ -1894,7 +1937,7 @@ export class HulyClient {
    * @param {string} projectIdent - Project identifier
    * @returns {Promise<Object[]>}
    */
-  async listTaskTypes(projectIdent) {
+  async listTaskTypes(projectIdent, options = {}) {
     const client = await this._getClient();
 
     const project = await client.findOne(tracker.class.Project, {
@@ -1923,7 +1966,7 @@ export class HulyClient {
       );
     }
 
-    return typesToReturn.map(tt => ({
+    const enriched = typesToReturn.map(tt => ({
       id: tt._id,
       name: tt.name || tt._id.split(':').pop(),
       description: fromMarkup(tt.description),
@@ -1934,6 +1977,7 @@ export class HulyClient {
       statusCategories: tt.statusCategories || [],
       statuses: tt.statuses || []
     }));
+    return this._cursoredFindAll(enriched, options);
   }
 
   /**
@@ -1942,20 +1986,21 @@ export class HulyClient {
    * @param {string} [taskTypeName] - Task type name to scope statuses (e.g., "Task", "Epic")
    * @returns {Promise<Object[]>}
    */
-  async listStatuses(projectIdent, taskTypeName) {
+  async listStatuses(projectIdent, taskTypeName, options = {}) {
     const client = await this._getClient();
 
     const allStatuses = await client.findAll(tracker.class.IssueStatus, {});
 
     // If no scoping requested, return all
     if (!projectIdent && !taskTypeName) {
-      return allStatuses.map(s => ({
+      const enriched = allStatuses.map(s => ({
         id: s._id,
         name: s.name,
         category: STATUS_CATEGORY_NAMES[s.category] || s.category,
         color: s.color,
         description: fromMarkup(s.description)
       }));
+      return this._cursoredFindAll(enriched, options);
     }
 
     // Get task types scoped to this project
@@ -1996,13 +2041,14 @@ export class HulyClient {
       ? allStatuses.filter(s => statusIds.has(s._id))
       : allStatuses;
 
-    return scopedStatuses.map(s => ({
+    const enriched = scopedStatuses.map(s => ({
       id: s._id,
       name: s.name,
       category: STATUS_CATEGORY_NAMES[s.category] || s.category,
       color: s.color,
       description: s.description || ''
     }));
+    return this._cursoredFindAll(enriched, options);
   }
 
   /**
@@ -2036,7 +2082,7 @@ export class HulyClient {
     });
 
     if (!options.include_details) {
-      return milestones.map(m => withExtra(m, {
+      const enriched = milestones.map(m => withExtra(m, {
         id: m._id,
         name: m.label,
         description: fromMarkup(m.description),
@@ -2044,6 +2090,7 @@ export class HulyClient {
         targetDate: m.targetDate ? new Date(m.targetDate).toISOString().split('T')[0] : null,
         comments: m.comments || 0
       }));
+      return this._cursoredFindAll(enriched, options);
     }
 
     // Detailed mode: batch fetch all issues for the project, then group by milestone
@@ -2059,7 +2106,7 @@ export class HulyClient {
       }
     }
 
-    return milestones.map(m => {
+    const detailed = milestones.map(m => {
       const mIssues = (issuesByMilestone.get(m._id) || []).map(i => ({
         id: `${project.identifier}-${i.number}`,
         title: i.title,
@@ -2077,6 +2124,7 @@ export class HulyClient {
         issues: mIssues
       });
     });
+    return this._cursoredFindAll(detailed, options);
   }
 
   /**
@@ -2253,16 +2301,17 @@ export class HulyClient {
    * List all active workspace members.
    * @returns {Promise<Object[]>}
    */
-  async listMembers() {
+  async listMembers(options = {}) {
     const client = await this._getClient();
     const employees = await client.findAll(contactPlugin.mixin.Employee, { active: true });
-    return employees.map(e => withExtra(e, {
+    const enriched = employees.map(e => withExtra(e, {
       id: e._id,
       name: e.name,
       email: e.channels?.[0]?.value || null,
       role: e.role || 'USER',
       position: e.position || null
     }));
+    return this._cursoredFindAll(enriched, options);
   }
 
   /**
@@ -2326,7 +2375,7 @@ export class HulyClient {
    * @param {string} issueId - Issue identifier
    * @returns {Promise<Object[]>}
    */
-  async listComments(issueId) {
+  async listComments(issueId, options = {}) {
     const client = await this._getClient();
     const { issue } = await this._parseAndFindIssue(client, issueId);
 
@@ -2334,13 +2383,14 @@ export class HulyClient {
       attachedTo: issue._id
     }, { sort: { createdOn: 1 } });
 
-    return comments.map(c => withExtra(c, {
+    const enriched = comments.map(c => withExtra(c, {
       id: c._id,
       text: fromMarkup(c.message),
       createdBy: c.createdBy || null,
       createdOn: c.createdOn,
       modifiedOn: c.modifiedOn
     }));
+    return this._cursoredFindAll(enriched, options);
   }
 
   /**
@@ -2574,10 +2624,10 @@ export class HulyClient {
       }
     }
 
-    let issues = await this._paginatedFindAll(client, tracker.class.Issue, query, {
-      limit,
-      sort: { modifiedOn: -1 }
+    const fetchResult = await this._paginatedFindAll(client, tracker.class.Issue, query, {
+      limit
     });
+    const issues = fetchResult.items;
 
     const projects = await client.findAll(tracker.class.Project, {});
     const projMap = new Map(projects.map(p => [p._id, p.identifier]));
@@ -3367,7 +3417,7 @@ export class HulyClient {
 
   // ── Components ──────────────────────────────────────────────
 
-  async listComponents(projectIdent) {
+  async listComponents(projectIdent, options = {}) {
     const client = await this._getClient();
     const project = await client.findOne(tracker.class.Project, {
       identifier: projectIdent.toUpperCase()
@@ -3376,12 +3426,13 @@ export class HulyClient {
 
     const components = await client.findAll(tracker.class.Component, { space: project._id });
 
-    return components.map(c => withExtra(c, {
+    const enriched = components.map(c => withExtra(c, {
       id: c._id,
       name: c.label,
       description: fromMarkup(c.description),
       lead: c.lead || null
     }));
+    return this._cursoredFindAll(enriched, options);
   }
 
   async createComponent(projectIdent, name, description, lead, format) {
@@ -3486,7 +3537,7 @@ export class HulyClient {
 
   // ── Time Reports ────────────────────────────────────────────
 
-  async listTimeReports(issueId) {
+  async listTimeReports(issueId, options = {}) {
     const client = await this._getClient();
     const { issue } = await this._parseAndFindIssue(client, issueId);
 
@@ -3494,12 +3545,13 @@ export class HulyClient {
       attachedTo: issue._id
     }, { sort: { date: -1 } });
 
-    return reports.map(r => withExtra(r, {
+    const enriched = reports.map(r => withExtra(r, {
       id: r._id,
       hours: r.value,
       description: fromMarkup(r.description),
       date: r.date ? new Date(r.date).toISOString() : null
     }));
+    return this._cursoredFindAll(enriched, options);
   }
 
   async deleteTimeReport(reportId) {
@@ -3508,17 +3560,9 @@ export class HulyClient {
     const report = await client.findOne(tracker.class.TimeSpendReport, { _id: reportId });
     if (!report) throw new Error(`Time report not found: ${reportId}`);
 
-    // Update the issue's reportedTime
-    if (report.attachedTo) {
-      const issue = await client.findOne(tracker.class.Issue, { _id: report.attachedTo });
-      if (issue) {
-        const newReported = Math.max(0, (issue.reportedTime || 0) - (report.value || 0));
-        await client.updateDoc(tracker.class.Issue, issue.space, issue._id, {
-          reportedTime: newReported
-        });
-      }
-    }
-
+    // The transactor automatically decrements reportedTime on the issue
+    // when a TimeSpendReport is removed via removeCollection — do NOT
+    // manually update reportedTime here or it gets decremented twice.
     await client.removeCollection(tracker.class.TimeSpendReport, report.space, report._id, report.attachedTo, report.attachedToClass, report.collection);
 
     return {

--- a/src/dispatch.mjs
+++ b/src/dispatch.mjs
@@ -78,11 +78,11 @@ export const accountTools = {
  */
 export const workspaceTools = {
   list_projects: (a, c) =>
-    c.listProjects({ include_details: a.include_details }),
+    c.listProjects({ include_details: a.include_details, cursor: a.cursor, limit: a.limit }),
   get_project: (a, c) =>
     c.getProject(a.project, { include_details: a.include_details }),
   list_issues: (a, c) =>
-    c.listIssues(a.project, a.status, a.priority, a.label, a.milestone, a.limit, a.include_details),
+    c.listIssues(a.project, a.status, a.priority, a.label, a.milestone, a.limit, a.include_details, a.cursor),
   get_issue: (a, c) =>
     c.getIssue(a.issueId, { include_details: a.include_details }),
   create_issue: (a, c) =>
@@ -113,7 +113,7 @@ export const workspaceTools = {
   // Labels
   add_label: (a, c) => c.addLabel(a.issueId, a.label),
   remove_label: (a, c) => c.removeLabel(a.issueId, a.label),
-  list_labels: (a, c) => c.listLabels(),
+  list_labels: (a, c) => c.listLabels({ cursor: a.cursor, limit: a.limit }),
   create_label: (a, c) => c.createLabel(a.name, a.color, a.description),
   update_label: (a, c) =>
     c.updateLabel(a.name, { newName: a.newName, color: a.color, description: a.description }),
@@ -124,11 +124,11 @@ export const workspaceTools = {
   set_parent: (a, c) => c.setParent(a.issueId, a.parentIssueId),
 
   // Task types & statuses
-  list_task_types: (a, c) => c.listTaskTypes(a.project),
-  list_statuses: (a, c) => c.listStatuses(a.project, a.taskType),
+  list_task_types: (a, c) => c.listTaskTypes(a.project, { cursor: a.cursor, limit: a.limit }),
+  list_statuses: (a, c) => c.listStatuses(a.project, a.taskType, { cursor: a.cursor, limit: a.limit }),
 
   // Milestones
-  list_milestones: (a, c) => c.listMilestones(a.project, a.status, { include_details: a.include_details }),
+  list_milestones: (a, c) => c.listMilestones(a.project, a.status, { include_details: a.include_details, cursor: a.cursor, limit: a.limit }),
   get_milestone: (a, c) => c.getMilestone(a.project, a.name, { include_details: a.include_details }),
   create_milestone: (a, c) =>
     c.createMilestone(a.project, a.name, a.description, a.targetDate, a.status, a.descriptionFormat),
@@ -141,17 +141,17 @@ export const workspaceTools = {
   delete_milestone: (a, c) => c.deleteMilestone(a.project, a.name),
 
   // Members
-  list_members: (a, c) => c.listMembers(),
+  list_members: (a, c) => c.listMembers({ cursor: a.cursor, limit: a.limit }),
 
   // Comments
   add_comment: (a, c) => c.addComment(a.issueId, a.text, a.format),
-  list_comments: (a, c) => c.listComments(a.issueId),
+  list_comments: (a, c) => c.listComments(a.issueId, { cursor: a.cursor, limit: a.limit }),
   update_comment: (a, c) => c.updateComment(a.issueId, a.commentId, a.text, a.format),
   delete_comment: (a, c) => c.deleteComment(a.issueId, a.commentId),
 
   // Time tracking
   log_time: (a, c) => c.logTime(a.issueId, a.hours, a.description, a.descriptionFormat, a.date, a.employee),
-  list_time_reports: (a, c) => c.listTimeReports(a.issueId),
+  list_time_reports: (a, c) => c.listTimeReports(a.issueId, { cursor: a.cursor, limit: a.limit }),
   delete_time_report: (a, c) => c.deleteTimeReport(a.reportId),
 
   // Projects
@@ -166,7 +166,7 @@ export const workspaceTools = {
   delete_project: (a, c) => c.deleteProject(a.project),
 
   // Components
-  list_components: (a, c) => c.listComponents(a.project),
+  list_components: (a, c) => c.listComponents(a.project, { cursor: a.cursor, limit: a.limit }),
   create_component: (a, c) =>
     c.createComponent(a.project, a.name, a.description, a.lead, a.descriptionFormat),
   update_component: (a, c) =>

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -100,6 +100,30 @@ export const PAGE_SIZE = 500;
 export const MAX_BATCH_SIZE = 500;
 export const AUTH_CACHE_TTL_MS = 600000;
 export const DEFAULT_MILESTONE_DAYS = 30;
+export const DEFAULT_PAGE_SIZE = 50;
+export const DEFAULT_DETAIL_PAGE_SIZE = 20;
+
+/**
+ * Encode a pagination cursor from a createdOn timestamp.
+ * Returns an opaque base64url string.
+ */
+export function encodeCursor(createdOn) {
+  return Buffer.from(JSON.stringify({ createdOn })).toString('base64url');
+}
+
+/**
+ * Decode a pagination cursor back to { createdOn }.
+ * Throws on invalid input.
+ */
+export function decodeCursor(cursor) {
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString());
+    if (typeof parsed.createdOn !== 'number') throw new Error();
+    return parsed;
+  } catch {
+    throw new Error('Invalid pagination cursor');
+  }
+}
 
 /**
  * Resolve a color value: name ("blue"), palette index (9), or RGB (0x5E6AD2).

--- a/src/mcpShared.mjs
+++ b/src/mcpShared.mjs
@@ -31,6 +31,18 @@ const workspaceProp = {
   }
 };
 
+// Pagination properties for all list tools
+const paginationProps = {
+  cursor: {
+    type: 'string',
+    description: 'Opaque pagination cursor from a previous response\'s nextCursor field. Omit for the first page.'
+  },
+  limit: {
+    type: 'number',
+    description: 'Maximum items per page (default: 50, or 20 with include_details)'
+  }
+};
+
 // ── Tool Definitions ──────────────────────────────────────────
 
 export { workspaceProp };
@@ -112,9 +124,9 @@ export function createMcpServer(capabilities = {}) {
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
     try {
       const client = await pool.getClient();
-      const projects = await client.withReconnect(() => client.listProjects());
+      const result = await client.withReconnect(() => client.listProjects());
       return {
-        resources: projects.map(p => ({
+        resources: result.items.map(p => ({
           uri: `huly://projects/${p.identifier}`,
           name: `${p.identifier}: ${p.name}`,
           description: `Project with ${p.issueCount} issues`,
@@ -324,7 +336,7 @@ function getToolDefinitions() {
     {
       name: 'list_projects',
       description: 'List all projects in the Huly workspace. Returns each project\'s identifier (e.g., "PROJ"), display name, and total issue count. Use this first to discover available projects before querying issues. Set include_details=true to also fetch milestones, components, labels, and member names for each project (limited to 20 projects).',
-      inputSchema: { type: 'object', properties: { include_details: { type: 'boolean', description: 'Include milestones, components, labels, and members for each project (default: false). Limits to 20 projects.' }, ...workspaceProp }, required: [] }
+      inputSchema: { type: 'object', properties: { include_details: { type: 'boolean', description: 'Include milestones, components, labels, and members for each project (default: false). Limits to 20 projects.' }, ...paginationProps, ...workspaceProp }, required: [] }
     },
     {
       name: 'get_project',
@@ -333,8 +345,8 @@ function getToolDefinitions() {
     },
     {
       name: 'list_issues',
-      description: 'List issues in a project with optional filtering. Returns id, title, status, priority, type (Task/Epic/Bug), assignee, component, labels, milestone, parent issue, childCount, dueDate, estimation, reportedTime, createdOn, modifiedOn, and completedAt for each issue. Does NOT include full descriptions — use get_issue to read resolved markdown descriptions (important for migrations). Supports filtering by status, priority, label, and milestone. Default limit 500, auto-paginates. Use search_issues for full-text search across projects.',
-      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier (e.g., "PROJ")' }, status: { type: 'string', description: 'Filter by status: Backlog, Todo, In Progress, Done, Canceled' }, priority: { type: 'string', description: 'Filter by priority: urgent, high, medium, low, none' }, label: { type: 'string', description: 'Filter by label name (exact match)' }, milestone: { type: 'string', description: 'Filter by milestone name (exact match)' }, limit: { type: 'number', description: 'Maximum number of issues to return (default: 500)' }, include_details: { type: 'boolean', description: 'Include full details: descriptions, comments, time reports, relations, and children. Reduces default limit to 50.' }, ...workspaceProp }, required: ['project'] }
+      description: 'List issues in a project with optional filtering and cursor-based pagination. Returns { items, nextCursor? }. Pass nextCursor from a previous response to get the next page. Default page size: 50 (20 with include_details).',
+      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier (e.g., "PROJ")' }, status: { type: 'string', description: 'Filter by status: Backlog, Todo, In Progress, Done, Canceled' }, priority: { type: 'string', description: 'Filter by priority: urgent, high, medium, low, none' }, label: { type: 'string', description: 'Filter by label name (exact match)' }, milestone: { type: 'string', description: 'Filter by milestone name (exact match)' }, include_details: { type: 'boolean', description: 'Include full details: descriptions, comments, time reports, relations, and children. Reduces default page size to 20.' }, ...paginationProps, ...workspaceProp }, required: ['project'] }
     },
     {
       name: 'get_issue',
@@ -363,8 +375,8 @@ function getToolDefinitions() {
     },
     {
       name: 'list_labels',
-      description: 'List all available labels in the workspace. Returns each label\'s name and hex color. Use this to discover existing labels before adding them to issues.',
-      inputSchema: { type: 'object', properties: { ...workspaceProp }, required: [] }
+      description: 'List all available labels in the workspace. Returns { items, nextCursor? }. Each label has name and hex color.',
+      inputSchema: { type: 'object', properties: { ...paginationProps, ...workspaceProp }, required: [] }
     },
     {
       name: 'create_label',
@@ -459,8 +471,8 @@ function getToolDefinitions() {
     // ── Components ───────────────────────────────────────────
     {
       name: 'list_components',
-      description: 'List all components in a project.',
-      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier' }, ...workspaceProp }, required: ['project'] }
+      description: 'List all components in a project. Returns { items, nextCursor? }.',
+      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier' }, ...paginationProps, ...workspaceProp }, required: ['project'] }
     },
     {
       name: 'get_component',
@@ -486,8 +498,8 @@ function getToolDefinitions() {
     // ── Milestones ───────────────────────────────────────────
     {
       name: 'list_milestones',
-      description: 'List all milestones in a project. Returns name, status, date range, and issue count.',
-      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier' }, include_details: { type: 'boolean', description: 'Include issue list for each milestone' }, ...workspaceProp }, required: ['project'] }
+      description: 'List all milestones in a project. Returns { items, nextCursor? }.',
+      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier' }, include_details: { type: 'boolean', description: 'Include issue list for each milestone' }, ...paginationProps, ...workspaceProp }, required: ['project'] }
     },
     {
       name: 'get_milestone',
@@ -518,8 +530,8 @@ function getToolDefinitions() {
     // ── Members ──────────────────────────────────────────────
     {
       name: 'list_members',
-      description: 'List all active members of the workspace with their names and roles.',
-      inputSchema: { type: 'object', properties: { ...workspaceProp }, required: [] }
+      description: 'List all active members of the workspace. Returns { items, nextCursor? }.',
+      inputSchema: { type: 'object', properties: { ...paginationProps, ...workspaceProp }, required: [] }
     },
     {
       name: 'get_member',
@@ -530,8 +542,8 @@ function getToolDefinitions() {
     // ── Comments ─────────────────────────────────────────────
     {
       name: 'list_comments',
-      description: 'List all comments on an issue, ordered chronologically.',
-      inputSchema: { type: 'object', properties: { issueId: { type: 'string', description: 'Issue identifier (e.g., "PROJ-42")' }, ...workspaceProp }, required: ['issueId'] }
+      description: 'List comments on an issue. Returns { items, nextCursor? }.',
+      inputSchema: { type: 'object', properties: { issueId: { type: 'string', description: 'Issue identifier (e.g., "PROJ-42")' }, ...paginationProps, ...workspaceProp }, required: ['issueId'] }
     },
     {
       name: 'get_comment',
@@ -557,8 +569,8 @@ function getToolDefinitions() {
     // ── Metadata ─────────────────────────────────────────────
     {
       name: 'list_statuses',
-      description: 'List all issue statuses available in a project, grouped by category (Backlog, Unstarted, Active, Won, Lost).',
-      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier' }, ...workspaceProp }, required: ['project'] }
+      description: 'List issue statuses available in a project. Returns { items, nextCursor? }.',
+      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier' }, ...paginationProps, ...workspaceProp }, required: ['project'] }
     },
     {
       name: 'get_status',
@@ -567,8 +579,8 @@ function getToolDefinitions() {
     },
     {
       name: 'list_task_types',
-      description: 'List all task types available in a project (e.g., Issue, Epic, Bug).',
-      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier' }, ...workspaceProp }, required: ['project'] }
+      description: 'List task types available in a project. Returns { items, nextCursor? }.',
+      inputSchema: { type: 'object', properties: { project: { type: 'string', description: 'Project identifier' }, ...paginationProps, ...workspaceProp }, required: ['project'] }
     },
     {
       name: 'get_task_type',
@@ -584,8 +596,8 @@ function getToolDefinitions() {
     },
     {
       name: 'list_time_reports',
-      description: 'List all time reports for an issue.',
-      inputSchema: { type: 'object', properties: { issueId: { type: 'string', description: 'Issue identifier' }, ...workspaceProp }, required: ['issueId'] }
+      description: 'List time reports for an issue. Returns { items, nextCursor? }.',
+      inputSchema: { type: 'object', properties: { issueId: { type: 'string', description: 'Issue identifier' }, ...paginationProps, ...workspaceProp }, required: ['issueId'] }
     },
     {
       name: 'get_time_report',

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -279,7 +279,7 @@ function shutdown(signal) {
   timeout.unref();
 
   // Close all sessions
-  for (const [sid, session] of sessions) {
+  for (const session of sessions.values()) {
     session.transport.close().catch(() => {});
     session.server.close().catch(() => {});
   }

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -402,7 +402,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_projects', () => {
     it('returns projects including test project', async () => {
-      const projects = await client.listProjects();
+      const projects = (await client.listProjects()).items;
       assert.ok(Array.isArray(projects), 'Should return an array');
       assert.ok(projects.length > 0, 'Should have at least one project');
 
@@ -437,7 +437,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_issues', () => {
     it('returns issues for OPS', async () => {
-      const issues = await client.listIssues(PROJECT, undefined, undefined, undefined, undefined, 5);
+      const issues = (await client.listIssues(PROJECT, undefined, undefined, undefined, undefined, 5)).items;
       assert.ok(Array.isArray(issues));
       // OPS may have very few issues
       if (issues.length > 0) {
@@ -450,7 +450,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
     });
 
     it('respects limit parameter', async () => {
-      const issues = await client.listIssues(PROJECT, undefined, undefined, undefined, undefined, 5);
+      const issues = (await client.listIssues(PROJECT, undefined, undefined, undefined, undefined, 5)).items;
       assert.ok(issues.length <= 5);
     });
   });
@@ -459,7 +459,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_statuses', () => {
     it('returns available statuses', async () => {
-      const statuses = await client.listStatuses();
+      const statuses = (await client.listStatuses()).items;
       assert.ok(Array.isArray(statuses));
       assert.ok(statuses.length > 0);
       const names = statuses.map(s => s.name);
@@ -472,7 +472,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_members', () => {
     it('returns workspace members', async () => {
-      const members = await client.listMembers();
+      const members = (await client.listMembers()).items;
       assert.ok(Array.isArray(members));
       assert.ok(members.length > 0, 'Should have at least one member');
       const first = members[0];
@@ -484,7 +484,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_labels', () => {
     it('returns labels array', async () => {
-      const labels = await client.listLabels();
+      const labels = (await client.listLabels()).items;
       assert.ok(Array.isArray(labels));
       // May be empty if no labels exist yet, but should at least be an array
     });
@@ -494,7 +494,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_milestones', () => {
     it('returns milestones for OPS', async () => {
-      const milestones = await client.listMilestones(PROJECT);
+      const milestones = (await client.listMilestones(PROJECT)).items;
       assert.ok(Array.isArray(milestones));
       // Milestones may or may not exist, just verify it returns an array
     });
@@ -504,7 +504,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_task_types', () => {
     it('returns task types for OPS', async () => {
-      const types = await client.listTaskTypes(PROJECT);
+      const types = (await client.listTaskTypes(PROJECT)).items;
       assert.ok(Array.isArray(types));
       assert.ok(types.length > 0, 'Should have at least one task type');
       const names = types.map(t => t.name);
@@ -599,7 +599,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
     it('lists comments on the issue', async () => {
       assert.ok(lifecycleIssueId, 'Lifecycle issue must exist');
-      const comments = await client.listComments(lifecycleIssueId);
+      const comments = (await client.listComments(lifecycleIssueId)).items;
       assert.ok(Array.isArray(comments));
       assert.ok(comments.length >= 1, 'Should have at least one comment');
       const found = comments.some(c =>
@@ -631,7 +631,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
       assert.ok(lifecycleIssueId, 'Lifecycle issue must exist');
       const result = await client.logTime(lifecycleIssueId, 1.5, 'Test time log');
       assert.ok(result, 'Should return a result');
-      const reports = await client.listTimeReports(lifecycleIssueId);
+      const reports = (await client.listTimeReports(lifecycleIssueId)).items;
       assert.ok(Array.isArray(reports));
       assert.ok(reports.some(r => r.hours === 1.5), 'Should find the 1.5h time entry');
     });
@@ -778,7 +778,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
   describe('assign_issue', () => {
     it('assigns the lifecycle issue to a member', async () => {
       assert.ok(lifecycleIssueId, 'Lifecycle issue must exist');
-      const members = await client.listMembers();
+      const members = (await client.listMembers()).items;
       assert.ok(members.length > 0, 'Need at least one member');
       const result = await client.assignIssue(lifecycleIssueId, members[0].name);
       assert.ok(result);
@@ -939,7 +939,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
     });
 
     it('reads back the created component', async () => {
-      const components = await client.listComponents(PROJECT);
+      const components = (await client.listComponents(PROJECT)).items;
       assert.ok(Array.isArray(components));
       const found = components.find(c => c.name === compName);
       assert.ok(found, 'Should find the created component');
@@ -952,7 +952,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
     });
 
     it('reads back the updated component', async () => {
-      const components = await client.listComponents(PROJECT);
+      const components = (await client.listComponents(PROJECT)).items;
       const found = components.find(c => c.name === compName);
       assert.ok(found, 'Should find the component');
       assert.equal(found.description, 'Updated desc');
@@ -1002,7 +1002,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
     });
 
     it('lists time reports', async () => {
-      const reports = await client.listTimeReports(testIssueId);
+      const reports = (await client.listTimeReports(testIssueId)).items;
       assert.ok(Array.isArray(reports));
       assert.ok(reports.length >= 1);
       assert.ok(reports.some(r => r.id === reportId));
@@ -1035,7 +1035,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
     });
 
     it('verifies comment was updated', async () => {
-      const comments = await client.listComments(testIssueId);
+      const comments = (await client.listComments(testIssueId)).items;
       const updated = comments.find(c => c.id === commentId);
       assert.ok(updated);
       assert.equal(updated.text, 'Updated text');
@@ -1064,7 +1064,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('get_member', () => {
     it('finds a member by name', async () => {
-      const members = await client.listMembers();
+      const members = (await client.listMembers()).items;
       assert.ok(members.length > 0, 'Should have at least one member');
       const member = await client.getMember(members[0].name);
       assert.equal(member.name, members[0].name);
@@ -1108,7 +1108,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('get_task_type', () => {
     it('finds a task type by name', async () => {
-      const types = await client.listTaskTypes(PROJECT);
+      const types = (await client.listTaskTypes(PROJECT)).items;
       assert.ok(types.length > 0, 'Should have at least one task type');
       const tt = await client.getTaskType(PROJECT, types[0].name);
       assert.equal(tt.name, types[0].name);
@@ -1193,14 +1193,14 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_issues with include_details', () => {
     it('returns descriptions when include_details is true', async () => {
-      const issues = await client.listIssues(PROJECT, null, null, null, null, 5, true);
+      const issues = (await client.listIssues(PROJECT, null, null, null, null, 5, true)).items;
       assert.ok(issues.length > 0, 'Should have issues');
       const withDesc = issues.find(i => i.description && i.description.length > 0);
       assert.ok(withDesc, 'At least one issue should have a resolved description');
     });
 
     it('omits descriptions by default', async () => {
-      const issues = await client.listIssues(PROJECT, null, null, null, null, 5);
+      const issues = (await client.listIssues(PROJECT, null, null, null, null, 5)).items;
       assert.ok(issues.length > 0);
       // Default list should not have description at top level
       // (it may be in extra but not resolved)
@@ -1226,7 +1226,7 @@ describe('Integration Tests', { timeout: 120_000 }, () => {
 
   describe('list_projects with include_details', () => {
     it('returns enriched projects with include_details', async () => {
-      const projects = await client.listProjects({ include_details: true });
+      const projects = (await client.listProjects({ include_details: true })).items;
       assert.ok(projects.length > 0);
       const proj = projects.find(p => p.identifier === PROJECT);
       assert.ok(proj, 'Should find test project');
@@ -1439,7 +1439,7 @@ describe('v2.0.2 Audit Tests', { timeout: 120_000 }, () => {
       // Create an issue first
       const issue = await client.createIssue(AUDIT_PROJECT, 'Assign test');
       // Get actual members to construct a partial name
-      const members = await client.listMembers();
+      const members = (await client.listMembers()).items;
       if (members.length > 0) {
         const fullName = members[0].name;
         const partial = fullName.slice(0, 2); // First 2 chars — should NOT match
@@ -1463,7 +1463,7 @@ describe('v2.0.2 Audit Tests', { timeout: 120_000 }, () => {
     it('returns completedAt when issue is in done status', async () => {
       const issue = await client.createIssue(AUDIT_PROJECT, 'CompletedAt test');
       // Get available statuses and find a done one
-      const statuses = await client.listStatuses(AUDIT_PROJECT);
+      const statuses = (await client.listStatuses(AUDIT_PROJECT)).items;
       const doneStatus = statuses.find(s => s.category?.includes('Won'));
       if (doneStatus) {
         await client.updateIssue(issue.id, { status: doneStatus.name });
@@ -1589,7 +1589,7 @@ describe('v2.0.2 Audit Tests', { timeout: 120_000 }, () => {
     });
 
     it('list_issues does not throw on orphaned parent', async () => {
-      const issues = await client.listIssues(AUDIT_PROJECT);
+      const issues = (await client.listIssues(AUDIT_PROJECT)).items;
       // Child may or may not survive parent deletion depending on Huly behavior
       // The key assertion: listIssues itself must not throw
       assert.ok(Array.isArray(issues), 'list_issues should return array');
@@ -1632,7 +1632,7 @@ describe('v2.0.2 Audit Tests', { timeout: 120_000 }, () => {
     });
 
     it('list_issues does not throw on orphaned component', async () => {
-      const issues = await client.listIssues(AUDIT_PROJECT);
+      const issues = (await client.listIssues(AUDIT_PROJECT)).items;
       const issue = issues.find(i => i.id === issueId);
       assert.ok(issue, 'Issue should be in list');
       assert.equal(issue.component, null, 'Orphaned component should be null');
@@ -1665,7 +1665,7 @@ describe('v2.0.2 Audit Tests', { timeout: 120_000 }, () => {
     });
 
     it('list_issues does not throw on orphaned milestone', async () => {
-      const issues = await client.listIssues(AUDIT_PROJECT);
+      const issues = (await client.listIssues(AUDIT_PROJECT)).items;
       const issue = issues.find(i => i.id === issueId);
       assert.ok(issue, 'Issue should be in list');
       assert.equal(issue.milestone, null, 'Orphaned milestone should be null');
@@ -2380,7 +2380,8 @@ describe('Streamable HTTP MCP Server Tests', { timeout: 120_000 }, () => {
       });
       assert.ok(res.body.result.content);
       const data = JSON.parse(res.body.result.content[0].text);
-      assert.ok(Array.isArray(data));
+      assert.ok(data.items, 'Response should have items array');
+      assert.ok(Array.isArray(data.items));
     });
   });
 
@@ -2392,8 +2393,8 @@ describe('Streamable HTTP MCP Server Tests', { timeout: 120_000 }, () => {
       });
       assert.ok(res.body.result.content);
       const data = JSON.parse(res.body.result.content[0].text);
-      assert.ok(Array.isArray(data));
-      assert.ok(data.length > 0);
+      assert.ok(data.items, 'Response should have items array');
+      assert.ok(data.items.length > 0);
     });
   });
 


### PR DESCRIPTION
- Implement MCP spec cursor-based pagination for all 10 list tools
- Return { items, nextCursor? } instead of raw arrays
- Default page size: 50 (20 with include_details)
- Fix deleteTimeReport double-decrementing reportedTime
- Add eslint config and lint script
- Add eslint + markdownlint-cli2 to CI pipeline
- Add OIDC Trusted Publishing for npm publish on merge to main
- Fix unused imports and prefer-const warnings

# Pull Request

## Summary

<!-- Brief description of changes -->

## Test Plan

- [ ] `npm test` passes
- [ ] `npx markdownlint-cli README.md` passes
- [ ] Round-trip verification for any new write operations
