### PR TITLE
Strip @hcengineering deps from tarball to fix npx install

### DIFF
--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -105,6 +105,23 @@ const tgzSrc = join(tmp, tgzName);
 const tgzDst = join(root, tgzName);
 cpSync(tgzSrc, tgzDst);
 
+// Rewrite the tarball's package.json to remove @hcengineering/* from
+// dependencies. npm resolves deps from registry metadata BEFORE extracting
+// bundled packages — keeping them in dependencies causes npm to fetch
+// Huly SDK versions with broken workspace: protocol references.
+const rewriteDir = join(root, '.pack-rewrite');
+if (existsSync(rewriteDir)) rmSync(rewriteDir, { recursive: true });
+mkdirSync(rewriteDir, { recursive: true });
+execSync(`tar xzf "${tgzDst}" -C "${rewriteDir}"`);
+const innerPkgPath = join(rewriteDir, 'package', 'package.json');
+const innerPkg = JSON.parse(readFileSync(innerPkgPath, 'utf8'));
+for (const dep of Object.keys(innerPkg.dependencies || {})) {
+  if (dep.startsWith('@hcengineering/')) delete innerPkg.dependencies[dep];
+}
+writeFileSync(innerPkgPath, JSON.stringify(innerPkg, null, 2) + '\n');
+execSync(`tar czf "${tgzDst}" -C "${rewriteDir}" package`);
+rmSync(rewriteDir, { recursive: true });
+
 // Clean up
 rmSync(tmp, { recursive: true });
 


### PR DESCRIPTION
## Summary
- Follow-up to #10 — the previous fix stripped deps from bundled packages' own `package.json` files and expanded `bundleDependencies`, but npm resolves the dependency tree from **registry metadata before extracting bundled packages**.
- The root `dependencies` field still listed `@hcengineering/*` entries, so npm fetched their registry versions which use `workspace:` protocol → install fails.
- **Fix**: After `npm pack`, rewrite the tarball's `package.json` to remove `@hcengineering/*` from `dependencies`. They remain in `bundleDependencies` and are physically bundled in `node_modules`.

## Test plan
- [ ] `npm run pack` produces tarball with `@hcengineering` only in `bundleDependencies`, not `dependencies`
- [ ] `npx --package=<tarball> huly-mcp-server` starts successfully from a clean directory
- [ ] `npm install <tarball>` in empty project succeeds with zero `workspace:` references