### PR TITLE
Fix MCP stdio: route SDK console.log off stdout (v2.2.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bgx4k3p/huly-mcp-server",
-  "version": "2.2.1",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bgx4k3p/huly-mcp-server",
-      "version": "2.2.1",
+      "version": "2.2.4",
       "bundleDependencies": [
         "@hcengineering/api-client",
         "@hcengineering/chunter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bgx4k3p/huly-mcp-server",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "MCP server for Huly issue tracking with stdio and Streamable HTTP transports",
   "type": "module",
   "license": "MIT",

--- a/src/mcp.mjs
+++ b/src/mcp.mjs
@@ -3,7 +3,17 @@
  * Huly MCP Server - stdio transport entry point for Claude Code.
  *
  * Uses the shared MCP server factory from mcpShared.mjs.
+ *
+ * IMPORTANT: MCP stdio transport requires stdout to carry only JSON-RPC
+ * messages. The Huly SDK writes diagnostic lines ("Generate new SessionId",
+ * "init DB complete", "Connected to server", "findfull model ...") via
+ * console.log, which corrupts framing and causes the client to drop the
+ * connection. Route console.log to stderr so the SDK's noise stays out of
+ * stdout. Actual JSON-RPC responses are written via process.stdout by the
+ * StdioServerTransport and are unaffected.
  */
+console.log = (...args) => console.error(...args);
+console.info = (...args) => console.error(...args);
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createMcpServer, PKG_VERSION } from './mcpShared.mjs';


### PR DESCRIPTION
## Summary

- MCP stdio transport was returning `Connection closed` from every Claude Code tool that exercised the Huly workspace-connect path (`list_projects`, `list_labels`, `get_my_issues`, `search_issues`, etc.) after the Huly stack was upgraded to `0.7.392`.
- Root cause: the Huly SDK at 0.7.392 emits diagnostic lines via `console.log` during workspace connect (`Generate new SessionId`, `init DB complete`, `Connected to server`, `findfull model ...`, plus `no document found, failed to apply model transaction` warnings). These land on **stdout**, which MCP stdio reserves for JSON-RPC frames. `@modelcontextprotocol/sdk` 1.29.0 enforces framing strictly and drops the transport on the first non-JSON line.
- Fix: rebind `console.log` / `console.info` to `console.error` at the top of `src/mcp.mjs`. Actual JSON-RPC responses go through `process.stdout.write` inside `StdioServerTransport` and are unaffected. HTTP transport (`src/server.mjs`) unchanged.
- Bump to `2.2.4`.

## Why it only broke now

The `console.log` calls are in the SDK, not this repo — older SDK versions were quieter during the connect handshake, and older `@modelcontextprotocol/sdk` versions were lenient about non-JSON lines on stdout. The Huly stack upgrade started producing the noise; the MCP SDK bump stopped tolerating it. Either alone was survivable; together they're fatal.

## Test plan

- [x] `npm run lint` — passes
- [x] Direct stdio harness: 9 JSON-RPC requests → 9 valid JSON-RPC responses on stdout, 0 non-JSON lines
- [x] Live MCP client (Claude Code): `list_projects`, `list_labels`, `get_my_issues`, `search_issues` all succeed (previously all returned `Connection closed`)
- [x] Stderr sanity-checked — SDK diagnostics correctly rerouted there
- [ ] CI (`lint + unit + mock` tests) passes
- [ ] Post-merge: verify `npm publish` job fires and `2.2.4` lands on the registry