### PR TITLE
fix(comments): serialize message as ProseMirror markup string

### DIFF
--- a/src/client.mjs
+++ b/src/client.mjs
@@ -15,7 +15,7 @@ import {
   encodeCursor, decodeCursor,
   nameMatch, strictGet, withExtra,
   toCollaboratorMarkup, fromCollaboratorMarkup,
-  toMarkup, fromMarkup
+  toMarkup, toMarkupString, fromMarkup
 } from './helpers.mjs';
 
 export { PRIORITY_MAP, PRIORITY_NAMES, MILESTONE_STATUS_MAP, MILESTONE_STATUS_NAMES };
@@ -2378,7 +2378,7 @@ export class HulyClient {
       issue._id,
       tracker.class.Issue,
       'comments',
-      { message: toMarkup(text, format), attachments: 0 },
+      { message: toMarkupString(text, format), attachments: 0 },
       commentId
     );
 
@@ -3597,7 +3597,7 @@ export class HulyClient {
     if (!comment) throw new Error(`Comment not found: ${commentId}`);
 
     await client.updateDoc(chunter.class.ChatMessage, project._id, commentId, {
-      message: toMarkup(text, format)
+      message: toMarkupString(text, format)
     });
 
     return {

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -246,6 +246,36 @@ export function toMarkup(text, format = 'markdown') {
 }
 
 /**
+ * Convert text to a Huly markup STRING (ProseMirror JSON stringified).
+ *
+ * Use this for fields stored inline on a doc (e.g. ChatMessage.message)
+ * where the UI expects a markup string, NOT a MarkupContent object.
+ * Fields stored as collaborator blobs (e.g. Issue.description) should
+ * keep using `toMarkup` so the api-client's uploadMarkup pipeline runs.
+ */
+export function toMarkupString(text, format = 'markdown') {
+  const emptyDoc = { type: 'doc', content: [] };
+  if (!text) return jsonToMarkup(emptyDoc);
+  let json;
+  switch (format) {
+    case 'html':
+      json = htmlToMarkup(text);
+      break;
+    case 'plain':
+      json = {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
+      };
+      break;
+    case 'markdown':
+    default:
+      json = markdownToMarkup(text);
+      break;
+  }
+  return jsonToMarkup(json);
+}
+
+/**
  * Extract text from a Huly description/message field.
  * Handles: MarkupContent objects, ProseMirror JSON strings, plain strings,
  * and collaborator reference strings.


### PR DESCRIPTION
Closes #20.

## Context

`ChatMessage.message` is an inline attribute that the Huly tracker UI reads as a ProseMirror JSON string. Prior to this change, `addComment` and `updateComment` passed a `MarkupContent` object (the output of `toMarkup`), which got persisted inline as `{ content, kind }`. The record was created on the server and retrievable via `list_comments`, but the UI rendered the comment as an empty \"User left a comment\" with the text hidden inside a thread reply — see #20 for full repro and root cause.

Collaborator-backed attributes like `Issue.description` are unaffected: there, `api-client.processMarkup` detects the `MarkupContent` and runs `uploadMarkup`. Only inline markup fields exhibited this mismatch.

## Changes

- **`src/helpers.mjs`** — add `toMarkupString(text, format)`. Converts the input into a ProseMirror document JSON (via `markdownToMarkup` / `htmlToMarkup` / a hand-built paragraph node for `plain`) and returns the stringified form using `jsonToMarkup`. `toMarkup` is preserved for callers that write to collaborator-backed fields.
- **`src/client.mjs`** — `addComment` (L2381) and `updateComment` (L3600) now use `toMarkupString`. Import updated accordingly.

No new dependencies. No schema or API changes. No changes to the description path.

## Validation

Tested against a self-hosted Huly instance (v2.2.4 of this server + latest Huly) with a live tracker project:

1. `add_comment({ issueId: 'INCEN-9', text: '## Hello\n\n**bold**\n\n- list item', format: 'markdown' })` — UI renders the heading, bold run, and list as expected.
2. Same call with `format: 'plain'` — renders as a plain paragraph.
3. Same call with `format: 'html'` — renders the HTML structure.
4. `update_comment` path verified by editing an existing comment and observing the new content render correctly.
5. Existing `Issue.description` flow (via `update_issue`) unaffected — descriptions still flow through the collaborator upload path and render correctly.

## Notes

- I kept the `toMarkup` helper intact because it's still used in several collaborator-backed paths (`description` in issues, projects, etc.). Only the inline ChatMessage callsites were migrated.
- If maintainers prefer a different naming or want the logic inlined, happy to iterate.