### PR TITLE
Add project-scoped Codex MCP config helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,18 @@ May also work with [Huly Cloud](https://app.huly.io) (not yet tested).
 
 Huly has no public API. The only programmatic access is through their JavaScript SDK,
 which connects via WebSocket. This server wraps that SDK and exposes **MCP tools**
-over both stdio and **Streamable HTTP** transports — compatible with Claude Code,
-VS Code, n8n, and any MCP client.
+over both stdio and **Streamable HTTP** transports — compatible with Codex,
+Claude Code, VS Code, n8n, and any MCP client.
+
+## Documentation Map
+
+- **Install**: add the package to a project or run it with `npx`.
+- **Quick Start**: configure Huly authentication.
+- **Integrations**: connect Codex, Claude Code, HTTP clients, or Docker.
+- **Configuration Reference**: environment variables and workspace behavior.
+- **Network Configurations**: local, remote, and Cloudflare tunnel notes.
+- **Development and Publishing**: tests, linting, and package publishing.
+- **API Reference**: available MCP tools and response conventions.
 
 ## Install
 
@@ -42,23 +52,13 @@ cd huly-mcp-server
 npm install
 ```
 
-### Publishing
-
-The Huly SDK has `workspace:` protocol references in transitive
-dependencies on the npm registry. The custom pack script bundles
-only the needed SDK packages and prunes UI bloat (32MB to 4MB):
-
-```bash
-npm run pack
-npm publish bgx4k3p-huly-mcp-server-<version>.tgz --access public
-```
-
 ---
 
 ## Quick Start
 
 ### Authentication
 
+Configure Huly access first, then choose one integration in the next section.
 You can authenticate with either **email/password** or a **token**.
 
 #### Email and Password
@@ -75,8 +75,14 @@ export HULY_WORKSPACE=your-workspace
 Get a token from your Huly credentials — no env vars needed beforehand:
 
 ```bash
-node src/index.mjs --get-token -e your@email.com -p your-password -u https://your-huly-instance.com
+npx -y @bgx4k3p/huly-mcp-server --get-token \
+  -e your@email.com \
+  -p your-password \
+  -u https://your-huly-instance.com
 ```
+
+From a source checkout, use `node src/index.mjs --get-token` with the same
+flags.
 
 Then use it:
 
@@ -89,19 +95,80 @@ export HULY_WORKSPACE=your-workspace
 The token does not expire. You can store it in a secrets manager
 and stop exposing your password in environment variables.
 
+For local stdio clients, the project config examples below set
+`HULY_WORKSPACE` per repo. Optionally set `HULY_PROJECT` when a repository maps
+cleanly to one Huly project. After connecting a client, call
+`get_huly_context` first to verify that the workspace, project, URL host, and
+auth mode are what you expect.
+
 ---
 
 ## Integrations
 
-### Claude Code (stdio)
+Use stdio for local coding agents and Streamable HTTP for remote clients or
+automation systems.
 
-After cloning and running `npm install`, register the server:
+### Codex (project-scoped stdio)
+
+Codex supports MCP servers from `config.toml`. For project-specific Huly
+workspaces, generate a repo-local Codex config layer:
+
+```bash
+npx -y @bgx4k3p/huly-mcp-server --init-codex --workspace my-workspace
+```
+
+Optionally set a default project identifier for project-scoped tools:
+
+```bash
+npx -y @bgx4k3p/huly-mcp-server --init-codex --workspace my-workspace --project PROJ
+```
+
+This creates `.codex/config.toml`:
+
+```toml
+[mcp_servers.huly]
+command = "npx"
+args = ["-y", "@bgx4k3p/huly-mcp-server"]
+env_vars = ["HULY_URL", "HULY_TOKEN"]
+startup_timeout_sec = 20
+tool_timeout_sec = 120
+
+[mcp_servers.huly.env]
+HULY_WORKSPACE = "my-workspace"
+HULY_PROJECT = "PROJ"
+```
+
+Keep secrets like `HULY_URL` and `HULY_TOKEN` in your user environment.
+Set `HULY_WORKSPACE` literally in each Codex or Claude project config so every
+repo, workspace folder, or editor project points to the intended Huly
+workspace. `HULY_PROJECT` is optional; when present, tools that naturally
+operate inside one project can omit the `project` argument. Explicit tool
+arguments still win.
+
+After starting a fresh Codex session in the project, run `get_huly_context`.
+It returns sanitized runtime context: default workspace, default project,
+Huly URL host, auth mode, and package version.
+
+Codex may show local stdio MCP servers as `unauthenticated` in `/mcp`.
+That label refers to MCP-level authentication, not Huly authentication.
+Use `get_huly_context` to confirm the downstream Huly auth mode is `token`
+or `email_password`.
+
+### Claude Code (project-scoped stdio)
+
+Generate `.mcp.json` for Claude Code:
+
+```bash
+npx -y @bgx4k3p/huly-mcp-server --init-claude --workspace my-workspace
+```
+
+Or add the server manually from a local source checkout:
 
 ```bash
 claude mcp add huly \
   -e HULY_URL=https://your-huly-instance.com \
   -e HULY_TOKEN=your-token \
-  -e HULY_WORKSPACE=your-workspace \
+  -e HULY_WORKSPACE=my-workspace \
   -- node /absolute/path/to/huly-mcp-server/src/index.mjs
 ```
 
@@ -114,12 +181,25 @@ Or add to your `.mcp.json` manually (token auth — recommended):
       "command": "node",
       "args": ["/path/to/huly-mcp-server/src/index.mjs"],
       "env": {
-        "HULY_URL": "https://your-huly-instance.com",
+        "HULY_URL": "${HULY_URL}",
         "HULY_TOKEN": "${HULY_TOKEN}",
-        "HULY_WORKSPACE": "${HULY_WORKSPACE}"
+        "HULY_WORKSPACE": "my-workspace"
       }
     }
   }
+}
+```
+
+For project-specific workspaces, keep secrets in environment variables and set
+the workspace slug literally in each repo. `HULY_PROJECT` is optional; set it
+only when the repo maps cleanly to one Huly project:
+
+```json
+"env": {
+  "HULY_URL": "${HULY_URL}",
+  "HULY_TOKEN": "${HULY_TOKEN}",
+  "HULY_WORKSPACE": "my-workspace",
+  "HULY_PROJECT": "PROJ"
 }
 ```
 
@@ -132,25 +212,32 @@ Or with email/password:
       "command": "node",
       "args": ["/path/to/huly-mcp-server/src/index.mjs"],
       "env": {
-        "HULY_URL": "https://your-huly-instance.com",
+        "HULY_URL": "${HULY_URL}",
         "HULY_EMAIL": "${HULY_EMAIL}",
         "HULY_PASSWORD": "${HULY_PASSWORD}",
-        "HULY_WORKSPACE": "${HULY_WORKSPACE}"
+        "HULY_WORKSPACE": "my-workspace"
       }
     }
   }
 }
 ```
 
-Then ask Claude things like:
+### Generate Both Project Configs
 
-- "List my issues in the OPS project"
-- "Create a bug report for the login page crash"
-- "Summarize the PROJ project — what's overdue?"
-- "Break down this feature into subtasks using the feature template"
+```bash
+npx -y @bgx4k3p/huly-mcp-server --init-all --workspace my-workspace
+```
 
-All tools have detailed descriptions optimized for AI agents.
-MCP Resources are also available at `huly://projects/{id}` and `huly://issues/{id}`.
+With an optional default project:
+
+```bash
+npx -y @bgx4k3p/huly-mcp-server --init-all --workspace my-workspace --project PROJ
+```
+
+`--init-claude` creates or updates `.mcp.json` while preserving other MCP
+servers. `--init-codex` creates `.codex/config.toml` for trusted Codex
+projects while preserving unrelated Codex settings. Existing Huly entries are
+not replaced unless `--force` is passed.
 
 ### Streamable HTTP (n8n, VS Code, remote clients)
 
@@ -195,9 +282,25 @@ docker run -i \
   huly-mcp-server node src/mcp.mjs
 ```
 
+### Verify the Connection
+
+In any MCP client, call `get_huly_context` first. It confirms the active
+workspace, optional project, Huly URL host, auth mode, and package version
+without exposing secrets.
+
+Then ask your MCP client things like:
+
+- "List my issues in the PROJ project"
+- "Create a bug report for the login page crash"
+- "Summarize the PROJ project — what's overdue?"
+- "Break down this feature into subtasks using the feature template"
+
+All tools have detailed descriptions optimized for AI agents.
+MCP Resources are also available at `huly://projects/{id}` and `huly://issues/{id}`.
+
 ---
 
-## Server Configuration
+## Configuration Reference
 
 ### Environment Variables
 
@@ -209,6 +312,7 @@ docker run -i \
 | `HULY_EMAIL` | No | - | Huly login email (required if no token) |
 | `HULY_PASSWORD` | No | - | Huly login password (required if no token) |
 | `HULY_WORKSPACE` | Yes* | - | Default workspace slug |
+| `HULY_PROJECT` | No | - | Optional default project identifier for project-scoped tools |
 | `HULY_TRANSPORT` | No | `ws` | SDK transport: `ws` (WebSocket) or `rest` (REST API) |
 | `HULY_POOL_TTL_MS` | No | `1800000` | Connection pool TTL in ms (30 min) |
 | **HTTP Server** | | | |
@@ -235,7 +339,7 @@ MCP_AUTH_TOKEN=your-token-here npm run start:server
 
 If `MCP_AUTH_TOKEN` is not set, auth is disabled (fine for local-only usage).
 
-MCP stdio mode (Claude Code) does not use this token — stdio is inherently local.
+MCP stdio mode does not use this token — stdio is inherently local.
 
 ### Multi-Workspace
 
@@ -247,33 +351,6 @@ caches clients by workspace slug with configurable TTL:
 ```
 
 If omitted, the `HULY_WORKSPACE` env var is used as the default.
-
----
-
-## Testing
-
-Uses Node.js built-in `node:test` and `node:assert` — no test framework dependencies.
-Tests run twice: once with WebSocket transport, once with REST transport.
-
-```bash
-npm test              # Both transports (ws + rest)
-npm run test:ws       # WebSocket only
-npm run test:rest     # REST only
-```
-
-194 tests across 101 suites:
-
-| Suite | Tests | Description |
-| --- | --- | --- |
-| **Unit** | 28 | Constants, ID parsing, rate limiting, auth logic |
-| **Integration** | 55 | Full CRUD lifecycle against live Huly |
-| **Dispatch** | 45 | Schema to dispatch to client param forwarding for all tools |
-| **Account-level** | 11 | Workspaces, profile, social IDs |
-| **Mock** | 44 | Destructive ops, token auth via mocks |
-| **Streamable HTTP** | 11 | MCP protocol over HTTP: init, tools, resources, auth, rate limiting |
-
-**100% dispatch coverage** — every tool's params are traced end-to-end
-through the dispatch table to the client method.
 
 ---
 
@@ -296,6 +373,57 @@ bypass Application for `/_*` or these individual paths:
 
 ---
 
+## Testing
+
+Uses Node.js built-in `node:test` and `node:assert` — no test framework dependencies.
+The live integration suite runs twice: once with WebSocket transport and once
+with REST transport. Focused unit suites cover dispatch, MCP tool metadata, and
+project config generation.
+
+```bash
+npm test              # Both transports (ws + rest)
+npm run test:ws       # WebSocket only
+npm run test:rest     # REST only
+```
+
+Test coverage:
+
+| Suite | Description |
+| --- | --- |
+| **Unit** | Constants, ID parsing, rate limiting, auth logic |
+| **Integration** | Full CRUD lifecycle against live Huly |
+| **Dispatch** | Schema to dispatch to client param forwarding for all tools |
+| **MCP metadata** | Tool registration, `get_huly_context`, default project schemas |
+| **Project config** | `--init-claude`, `--init-codex`, `--init-all` helpers |
+| **Account-level** | Workspaces, profile, social IDs |
+| **Mock** | Destructive ops, token auth via mocks |
+| **Streamable HTTP** | MCP protocol over HTTP: init, tools, resources, auth, rate limiting |
+
+**100% dispatch coverage** — every tool's params are traced end-to-end
+through the dispatch table to the client method.
+
+---
+
+## Development and Publishing
+
+For local development:
+
+```bash
+npm install
+npm run lint
+node --test test/initCodex.test.mjs test/mcpShared.test.mjs
+```
+
+The custom pack script bundles only the Huly SDK packages needed at runtime
+and prunes UI/frontend bloat from the published tarball:
+
+```bash
+npm run pack
+npm publish bgx4k3p-huly-mcp-server-<version>.tgz --access public
+```
+
+---
+
 ## Architecture
 
 ```text
@@ -305,14 +433,15 @@ src/
   dispatch.mjs  # Tool-to-method dispatch table
   pool.mjs      # Connection pool — caches clients by workspace with TTL
   mcpShared.mjs # Shared MCP server factory — tool definitions + resources
-  mcp.mjs       # MCP stdio entry point (Claude Code)
+  mcp.mjs       # MCP stdio entry point (Codex, Claude Code)
   server.mjs    # MCP Streamable HTTP entry point (n8n, VS Code, remote)
-  index.mjs     # CLI entry point — --get-token mode + MCP re-export
+  initCodex.mjs # Project config helpers for Codex and Claude Code
+  index.mjs     # CLI entry point — --get-token, --init-* modes + MCP re-export
 ```
 
 ```text
-Claude Code  -> stdio           -> mcp.mjs    -> mcpShared.mjs -> pool -> client -> Huly SDK
-n8n / remote -> Streamable HTTP -> server.mjs -> mcpShared.mjs -> pool -> client -> Huly SDK
+Claude / Codex -> stdio           -> mcp.mjs    -> mcpShared.mjs -> pool -> client -> Huly SDK
+n8n / remote   -> Streamable HTTP -> server.mjs -> mcpShared.mjs -> pool -> client -> Huly SDK
 ```
 
 ---
@@ -360,6 +489,7 @@ Full list of all MCP tools available through this server.
 
 | Tool | Description |
 | --- | --- |
+| `get_huly_context` | Show sanitized runtime context: default workspace, default project, Huly URL host, auth mode, and package version |
 | `list_workspaces` | List all accessible workspaces |
 | `get_workspace_info` | Get workspace details by slug |
 | `create_workspace` | Create a new workspace |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,22 +8,36 @@
       "name": "@bgx4k3p/huly-mcp-server",
       "version": "2.2.4",
       "bundleDependencies": [
+        "@hcengineering/account-client",
+        "@hcengineering/analytics",
         "@hcengineering/api-client",
         "@hcengineering/chunter",
+        "@hcengineering/client",
+        "@hcengineering/client-resources",
+        "@hcengineering/collaborator-client",
+        "@hcengineering/contact",
         "@hcengineering/core",
+        "@hcengineering/measurements",
+        "@hcengineering/platform",
+        "@hcengineering/rank",
+        "@hcengineering/rpc",
         "@hcengineering/tags",
         "@hcengineering/task",
+        "@hcengineering/text",
+        "@hcengineering/text-core",
+        "@hcengineering/text-html",
+        "@hcengineering/text-markdown",
         "@hcengineering/tracker"
       ],
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@hcengineering/api-client": "^0.7.3",
-        "@hcengineering/chunter": "^0.7.0",
-        "@hcengineering/core": "^0.7.4",
-        "@hcengineering/tags": "^0.7.0",
-        "@hcengineering/task": "^0.7.0",
-        "@hcengineering/tracker": "^0.7.0",
+        "@hcengineering/api-client": "^0.7.423",
+        "@hcengineering/chunter": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/tags": "^0.7.423",
+        "@hcengineering/task": "^0.7.423",
+        "@hcengineering/tracker": "^0.7.423",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "jsdom": "^29.0.0"
       },
@@ -109,9 +123,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -440,56 +454,56 @@
       }
     },
     "node_modules/@hcengineering/account-client": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/@hcengineering/account-client/-/account-client-0.7.20.tgz",
-      "integrity": "sha512-Qj5FzV5ywImEU/hHwI9rdKgpI2+Hh1+DZkogiu5S43mY3qprVqENoyp+iS9jJUvUQNzdpMtM3gFjFvyK03pZdQ==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/account-client/-/account-client-0.7.423.tgz",
+      "integrity": "sha512-1G9sAMEbiPpf5M19n1RzLX/dz4Rxr0bkXjWfh0iVhWDc9GKgBRzKeLf8Qw+ji+xa8zNHhdgb4TJQUcAG/32ymg==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.23",
-        "@hcengineering/platform": "^0.7.19"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/activity": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/activity/-/activity-0.7.0.tgz",
-      "integrity": "sha512-7dNGUV7JBnxAuHs01ArvbpCJxsSAs4b0r+SS64W9R3YHtYp+9RN/UzjNhRL2EME0l+HjtxQwLuGbmkMvAzqWQw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/activity/-/activity-0.7.423.tgz",
+      "integrity": "sha512-4Jvb1YZAf08YEyAuMxHeP+gyruQAl+83Phl/o9Anz5QPQSQ1/Dq6wvmGAiSgiUppCq94mxytSCxZT0E0/kxsKw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/contact": "^0.7.0",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0"
+        "@hcengineering/contact": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/analytics": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/@hcengineering/analytics/-/analytics-0.7.17.tgz",
-      "integrity": "sha512-AzB2DvmDctEJge8VeAHS3YyRYij/QQlARxa2OCNiY+Vv+2+OsQk0NZsw1yqZqsMkVJ40FTUrzOkI7UdM6RPO1Q==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/analytics/-/analytics-0.7.423.tgz",
+      "integrity": "sha512-ZsY4sfoQCjl66QdpVQ8O4ZsurcdN/rL8nyLZWeprYtXWIvmnfLt9D810YNQIjrQHMXAAeVQTshWUa1b73NLmgw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/platform": "^0.7.17"
+        "@hcengineering/platform": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/api-client": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/@hcengineering/api-client/-/api-client-0.7.18.tgz",
-      "integrity": "sha512-QALxpP2a4IgibHsnY/Qn+RV4/ITXmXG90CiiggHyv6BkgPUS0E0viBr8WhAh0S+flVMgybTmaxxpXX3OzvPCaA==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/api-client/-/api-client-0.7.423.tgz",
+      "integrity": "sha512-xgAOhIEuMxvv4eZjxuwNktQBWwRAegVsQULQK73p80d60ZDmG+bQKZqZaMFx4j+Phky2p7/G5tWDb7jTL4dqgA==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/account-client": "^0.7.17",
-        "@hcengineering/client": "^0.7.17",
-        "@hcengineering/client-resources": "^0.7.17",
-        "@hcengineering/collaborator-client": "^0.7.17",
-        "@hcengineering/core": "^0.7.18",
-        "@hcengineering/platform": "^0.7.17",
-        "@hcengineering/text": "^0.7.18",
-        "@hcengineering/text-markdown": "^0.7.18",
+        "@hcengineering/account-client": "^0.7.423",
+        "@hcengineering/client": "^0.7.423",
+        "@hcengineering/client-resources": "^0.7.423",
+        "@hcengineering/collaborator-client": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/text": "^0.7.423",
+        "@hcengineering/text-markdown": "^0.7.423",
         "snappyjs": "^0.7.0"
       },
       "optionalDependencies": {
@@ -497,160 +511,160 @@
       }
     },
     "node_modules/@hcengineering/attachment": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/attachment/-/attachment-0.7.0.tgz",
-      "integrity": "sha512-6GVR9dbI4WNeUzkyRBRzodnVh1shN4pRdRx4icAYDpjGrHjgGE+lHLe7qctHWeILYA6xrM6p8gqHI2niNYDFbg==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/attachment/-/attachment-0.7.423.tgz",
+      "integrity": "sha512-P/7lZ5KCOBY9w1QQ2J6tQaxE0gtWQ4ECSJidAlvDrRzg9N2U2OMx8h3XqP2qLJV7IKpEWBw7jludChEKbNGOcA==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/workbench": "^0.7.0"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/workbench": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/calendar": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/calendar/-/calendar-0.7.0.tgz",
-      "integrity": "sha512-TL4lUWo8zWN7iRgVC2occ0e7wJ44fb6GPEfM8yXlyoux4I43s+2bk7+qcMv6/FhFrmgUYF6+fj/GplBkmw+sqQ==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/calendar/-/calendar-0.7.423.tgz",
+      "integrity": "sha512-6FMNtUx9GUdZpnV0oWmR074Q1pjKwyFPntPFWbA6FPIjrokY8xBw3eyh7h85pBn++oqTqwPwn95zKAezbj2KHw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/contact": "^0.7.0",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/notification": "^0.7.0",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/setting": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0"
+        "@hcengineering/contact": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/notification": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/setting": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/card": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/card/-/card-0.7.0.tgz",
-      "integrity": "sha512-8tviVI1Hf8IE1EIMLd+VmWIE3T5wQz1CYIW7Dwd4Vc+1uZllGTYTM3cGT1jDbHWeQCgLcyG/OlGEKlpHl30Tew==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/card/-/card-0.7.423.tgz",
+      "integrity": "sha512-frP8mk7vvZBQZmr+Gxa92YeIF0jNEf+Gg1rwMG8i3H9wwRei4pSmUMHGpP9gzxwlrvzBWZp1K1i3T/clKbOeaQ==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/chunter": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/chunter/-/chunter-0.7.0.tgz",
-      "integrity": "sha512-flNuGYrwQrrtshCB/ro1b9x8X9gB3vAZcvx2C0fDQFdacoLcC5Et0iRXwLtRIxvHqqcc6Fdt5w4tPklS+sW4tw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/chunter/-/chunter-0.7.423.tgz",
+      "integrity": "sha512-6zSJButH3Xua0uJv3OP8ic1WVap9v/csbTnLT+mU30CLLQa+JLkcy3jZ89HlWJwXDlbw3SwVx5hBSLdvlidemA==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/activity": "^0.7.0",
-        "@hcengineering/contact": "^0.7.0",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/notification": "^0.7.0",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0",
-        "@hcengineering/workbench": "^0.7.0",
+        "@hcengineering/activity": "^0.7.423",
+        "@hcengineering/contact": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/notification": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423",
+        "@hcengineering/workbench": "^0.7.423",
         "fast-equals": "^5.2.2"
       }
     },
     "node_modules/@hcengineering/client": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/@hcengineering/client/-/client-0.7.18.tgz",
-      "integrity": "sha512-r42fZwfz/bizU4INMG39elQOkAW8E+uRLDZHp3DnLEXgnl/B2mfu1Q0xWkey1pj2//myuMAOocyT8a83ms2J/A==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/client/-/client-0.7.423.tgz",
+      "integrity": "sha512-7JgZIEo6Ka+g0slw6SqOcNitxZnK3NPktPAUow0R2hejXZO+UE0IspvbkjPn3NB4GkdrleBpiYo0PSmYi53Bfg==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.23",
-        "@hcengineering/platform": "^0.7.19"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/client-resources": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/@hcengineering/client-resources/-/client-resources-0.7.18.tgz",
-      "integrity": "sha512-nnskuWP6D5QN4Yjf/P/QLzJOi0kfntEos9R75nWrN0L08PvGfVASehgB/8J/Uwmm/LrdWcJVnw2+9bK11jGn4g==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/client-resources/-/client-resources-0.7.423.tgz",
+      "integrity": "sha512-Wq2S+dKyx6Dp6dzGkYFk16SRLfe2+2+Dj1S2oVNyfxQmAGDsQWATsT5MH6su4M/nmcOiFpurC4YQ5iTtZQE0yg==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/analytics": "^0.7.17",
-        "@hcengineering/client": "^0.7.18",
-        "@hcengineering/core": "^0.7.23",
-        "@hcengineering/platform": "^0.7.19",
-        "@hcengineering/rpc": "^0.7.17",
+        "@hcengineering/analytics": "^0.7.423",
+        "@hcengineering/client": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/rpc": "^0.7.423",
         "snappyjs": "^0.7.0"
       }
     },
     "node_modules/@hcengineering/collaborator-client": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/@hcengineering/collaborator-client/-/collaborator-client-0.7.17.tgz",
-      "integrity": "sha512-GPv6u0CGuu4IOJmiKq/omlH4xdDkOn6HV7oDhNskOohpoNuui+ucNeUj5lq6a4SQxQfAjwf6f44K53ZJe/ygIw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/collaborator-client/-/collaborator-client-0.7.423.tgz",
+      "integrity": "sha512-aEPTziWcCf+b3KWTy1Lhk2Z75UdqQlkSaI097DjnAhXq9sIF8rBO2cbMk5h8q9prOnPXcxF0AWMeZtpdfvRkgQ==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.17"
+        "@hcengineering/core": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/contact": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/contact/-/contact-0.7.0.tgz",
-      "integrity": "sha512-vrgkI/bZ74Mv/yCIXbv6pVCU/vHYEY8XJ+b2Xl79K4qrKP/+iArHTUtpquU0tqpC8eV5lTRbdrxSbFr6JXzNpw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/contact/-/contact-0.7.423.tgz",
+      "integrity": "sha512-ozoD3vAJB/7x2cYP3oO15qo98gHRcNgM9r3zZ0zLiC62CNpxEVbsJiVX0wg9FkrJWmRp2oLYkNN5rDvHVQOW+g==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/card": "^0.7.0",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/templates": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0"
+        "@hcengineering/card": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/templates": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/core": {
-      "version": "0.7.23",
-      "resolved": "https://registry.npmjs.org/@hcengineering/core/-/core-0.7.23.tgz",
-      "integrity": "sha512-2FmzSMUreuQPBrhTjMI72SY2C4dtw5HwxJlOHuvm8A3hthwU5IS9Kmk1H/8y2ZfiC7x1a7gqeCnRsm02BjcZfw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/core/-/core-0.7.423.tgz",
+      "integrity": "sha512-U4g1jcIbDOz4ZUICgbaDE0imcjJdYf7k0Qe9r5K62karb4Bglzsn74mR1IWtenAtyf7k5LYuWBzP2gQuuZnYIw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/analytics": "^0.7.17",
-        "@hcengineering/measurements": "^0.7.18",
-        "@hcengineering/platform": "^0.7.19",
+        "@hcengineering/analytics": "^0.7.423",
+        "@hcengineering/measurements": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
         "fast-equals": "^5.2.2"
       }
     },
     "node_modules/@hcengineering/measurements": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/@hcengineering/measurements/-/measurements-0.7.18.tgz",
-      "integrity": "sha512-4MxYthJhNWPfR389lN5cIFtrhzgmhi39Fx/dqIOOYF+6g0WWA6GtWXi+ORRM8l/AWKSastZqsWxMdBbT+0htdg==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/measurements/-/measurements-0.7.423.tgz",
+      "integrity": "sha512-miQGTdEr47ha/3cJX3MFbqbfSgnK277yTSCJ+4evTRlEAM1WvcqxBrHB+vDTJxt3enj9hCGdX39BtpLNvDR2gQ==",
       "inBundle": true,
       "license": "EPL-2.0"
     },
     "node_modules/@hcengineering/notification": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/notification/-/notification-0.7.0.tgz",
-      "integrity": "sha512-wO3P9XjupSV+qF5/6hqoD3tPL195RJcyC0QqGyKuH5BzZEo1EV5iUWXOHYsO4eNaNy4trj/yfX9G+6DVQudpUg==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/notification/-/notification-0.7.423.tgz",
+      "integrity": "sha512-gGFvvthBmi6074ZA6fs7PlENcdfYWLeXfOOkEPavdIxmNh7ilV/k1yAYNXiAGXBlzpfWWgRPkjlCmK23+tBGXA==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/activity": "^0.7.0",
-        "@hcengineering/contact": "^0.7.0",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/setting": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0"
+        "@hcengineering/activity": "^0.7.423",
+        "@hcengineering/contact": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/setting": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/platform": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/@hcengineering/platform/-/platform-0.7.19.tgz",
-      "integrity": "sha512-HdRJ81A1p/0P9qmHUsBeyWgIkkz00a9fNdxJWjftD0zG2g1UK0212cGy1nfY3PbCefaf3PW/RqHs/oEVInl4iA==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/platform/-/platform-0.7.423.tgz",
+      "integrity": "sha512-X+QYV5vuS4KrRAeLYzv6+eVSEU7MzOe2+Tb4aFFruM6NDDhq38iFQ3qTuKI1cuzgwefWNKKeZh8x41VIIkrF4w==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
@@ -658,104 +672,104 @@
       }
     },
     "node_modules/@hcengineering/preference": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/preference/-/preference-0.7.0.tgz",
-      "integrity": "sha512-VdmWaR20xu4KhFhRAr86IZ4lB8sPD8DieN0qacIB/EXkqgdYpDov0zCR4SYI1HLSk7YR7bhnEWZXTvGc1N8a6Q==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/preference/-/preference-0.7.423.tgz",
+      "integrity": "sha512-zMdOkbyXw0sSkrSJ7Dah2fywCyQAk7898SypQxMOTobrFxqgtBkVH/R0cVcfByH72ylAT+4tjy7LiWgbDAdNrQ==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/ui": "^0.7.0"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/rank": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/@hcengineering/rank/-/rank-0.7.17.tgz",
-      "integrity": "sha512-olGMdtWWaRvz3uDnFmn8GyCW+/yqfN7fqR3uR8F/HlecBMReoQOBsEQlExJAAU7hdIJPS6u+F3Ge82uaUUWejg==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/rank/-/rank-0.7.423.tgz",
+      "integrity": "sha512-/Kc4LjpaboHoZGGMl2Bt/IaeQskzeN37VzMBBgv8HbrBmOW8P3Wfbvj5alq6KvyyvtZhnjoODL3zTE20EAYYJg==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.17",
+        "@hcengineering/core": "^0.7.423",
         "lexorank": "~1.0.4"
       }
     },
     "node_modules/@hcengineering/rpc": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/@hcengineering/rpc/-/rpc-0.7.17.tgz",
-      "integrity": "sha512-DEd8EMc+Zxgnnk7v9ELj8bk0GpwcKG8rgaMDd2ZXk/JUx9l99RJoJ9/5rlSUHGv8SRxTq8DYJR85nU3aasVd9Q==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/rpc/-/rpc-0.7.423.tgz",
+      "integrity": "sha512-exoPef84nB3bNTEIP0yX4kIQIjUkfxpGvVceu/tsAoljSEqrwjpxGfJbqSbbeRcYpjWQ7jPIOAJuj9BiMLEhVw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.17",
-        "@hcengineering/platform": "^0.7.17",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
         "msgpackr": "^1.11.2"
       }
     },
     "node_modules/@hcengineering/setting": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/setting/-/setting-0.7.0.tgz",
-      "integrity": "sha512-HQAyYjHZeE0k29i5M8uzrCgM8VpbmHx+4J0uJiDrFT0Zlt75NEud6IZJ+1OmQ6+PAXpqrieK8ISYxSlvU/zrzw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/setting/-/setting-0.7.423.tgz",
+      "integrity": "sha512-RXpF9ua98dEUP3NXYkZmKaCIFbUD2mq3Ii6u/5AOx1mpZF15Y04nLYTIQYS3XgqivYunVAoUNWhh4yU1mrMIqw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/account-client": "^0.7.3",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/templates": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0"
+        "@hcengineering/account-client": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/templates": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/tags": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/tags/-/tags-0.7.0.tgz",
-      "integrity": "sha512-iqNNNYLm/23ET6uzw075OhmRL0z605wh4hacTFpCw8BMhYfr3hmOCnR456KXIqZBNQ02gty8yWj0Vt9C3KdkWQ==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/tags/-/tags-0.7.423.tgz",
+      "integrity": "sha512-+I00Iw9CB+Ad9RuD4GPYBjOM7c5ay1yQqAFCrPyunGdgkqmCIqoXt+kDpV4vxaSGjRvCjZhZ2R0OhwGRXTYnQw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/task": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/task/-/task-0.7.0.tgz",
-      "integrity": "sha512-/ARXN6fAyouUzyf2OUVfR/kokMRrVb5RhOCqxNS9b688xBHg8DoDIMkO4RI+0vbkb+S6ZTWQoZjf7zwTHhBO+w==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/task/-/task-0.7.423.tgz",
+      "integrity": "sha512-Xbgow5S9rW11ZsDBd1UZcRShZoNwL5hK2+D+9oueV8c3NEYKkJHeS6MZFZYAoroMPcnEivYC/P1CixG6Z6Gkbw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/contact": "^0.7.0",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/notification": "^0.7.0",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/rank": "^0.7.3",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0"
+        "@hcengineering/contact": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/notification": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/rank": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/templates": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/templates/-/templates-0.7.0.tgz",
-      "integrity": "sha512-1tmbv2Aw2/p5T0RPUunc/2s4c8bSdhOYN5NZTKl7KVA1W4RDjpg6rqcgls6IV+BuoIg3FFEWuVHVGin5fJClqg==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/templates/-/templates-0.7.423.tgz",
+      "integrity": "sha512-1N6DVmS0zqJs3DvHNC2TnJf60lyXkf/RzywYCWHWYeZyXD77LzevaTPCvQm5KaPaBrKX/dxXW5jVAVD2BM5zbw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/ui": "^0.7.0"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/text": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/@hcengineering/text/-/text-0.7.18.tgz",
-      "integrity": "sha512-0se5IwEF/7LoHcFqqxtx7WUEc0sfzaytsQeqs15gRfjLx0vJ/XMc/ZAj1lkpeLKMPXRQ0mCwdzMjxVzo3W9XDQ==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/text/-/text-0.7.423.tgz",
+      "integrity": "sha512-0VQUZjujfYs0PgMcMf090W5MYaieM5k/pugidPLbv8A6g2qgHCbdKMNbnCxly8rISITUnY4oEC9dPTVKEdL1UA==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.18",
-        "@hcengineering/text-core": "^0.7.18",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/text-core": "^0.7.423",
         "@tiptap/core": "^2.11.7",
         "@tiptap/extension-blockquote": "^2.11.7",
         "@tiptap/extension-bold": "^2.11.7",
@@ -777,6 +791,8 @@
         "@tiptap/extension-ordered-list": "^2.11.7",
         "@tiptap/extension-paragraph": "^2.11.7",
         "@tiptap/extension-strike": "^2.11.7",
+        "@tiptap/extension-subscript": "^2.11.7",
+        "@tiptap/extension-superscript": "^2.11.7",
         "@tiptap/extension-table": "^2.11.7",
         "@tiptap/extension-table-cell": "^2.11.7",
         "@tiptap/extension-table-header": "^2.11.7",
@@ -797,139 +813,137 @@
       }
     },
     "node_modules/@hcengineering/text-core": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/@hcengineering/text-core/-/text-core-0.7.18.tgz",
-      "integrity": "sha512-UZ/ZMwVcf60WpnYYcsA7RqYE4JlHnAGVdmUDHX2SYzXXvDIK7deGWD9AKyK4yqI1mb19ccyCr5fGyGoLxx9k/g==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/text-core/-/text-core-0.7.423.tgz",
+      "integrity": "sha512-ddYc0AFu+DEn9MQzcVUHC1kCvJdGjED8dH2ByesfRGm8lnN1kCtCUaIwyyzQkdo0zlklHyKaTLKS9vQp1qtpeA==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.18",
+        "@hcengineering/core": "^0.7.423",
         "fast-equals": "^5.2.2",
         "hash-it": "^6.0.0"
       }
     },
     "node_modules/@hcengineering/text-html": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/@hcengineering/text-html/-/text-html-0.7.18.tgz",
-      "integrity": "sha512-hGPgptTk2Kfvlg8lAniaFe8jpf3RD4mZD0eL6CoPlXTKylUOklOGHFGWId+QjUYGPLBVkODPErmZxrZKbkRSWg==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/text-html/-/text-html-0.7.423.tgz",
+      "integrity": "sha512-YFInsEJ9IbwIu2Ks5+sdXrGc63EqLnEAcFCXp43FkCBzmE3dVupDZCle/YGPyhmyHJbJDSshKKuYKJgzIBTARg==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/text-core": "^0.7.18",
+        "@hcengineering/text-core": "^0.7.423",
         "htmlparser2": "^9.0.0"
       }
     },
     "node_modules/@hcengineering/text-markdown": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/@hcengineering/text-markdown/-/text-markdown-0.7.20.tgz",
-      "integrity": "sha512-71omVJXpGR9UB1/SyfJJTofEoSa1MjxUR84IsKmM2C4ujjuOsnqIUedkdkgZdHeGkapFa2SLqtlIRGpcrDRKNw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/text-markdown/-/text-markdown-0.7.423.tgz",
+      "integrity": "sha512-AtJO1gC4Y0ELf7glNOoFZFQw3vycOnU4eIISW0QzW9YZc1GLd0mHJk+vWZwa5TVpiC26nnjF8+QDaVjod0mACg==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/text-core": "^0.7.18",
-        "@hcengineering/text-html": "^0.7.18",
+        "@hcengineering/text-core": "^0.7.423",
+        "@hcengineering/text-html": "^0.7.423",
         "fast-equals": "^5.2.2",
         "markdown-it": "^14.0.0"
       }
     },
     "node_modules/@hcengineering/theme": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/theme/-/theme-0.7.0.tgz",
-      "integrity": "sha512-n1sgpfNZuC+e9fO+en77DNgOE4quh0+IAy+r+/g65U+ENSD9nmUVFoym9IdwFnrUrTLPa4jyxncGrZ16fJtdsA==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/theme/-/theme-0.7.423.tgz",
+      "integrity": "sha512-aXFJWiBKiNdUECBuhnpeT9ZPD5B15Kqvl9vA759LvjVXRIs34jkK8RmKDVXtchNa6raj1Rbt5XW2Cn/35b+Twg==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/analytics": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
+        "@hcengineering/analytics": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
         "svelte": "^4.2.20"
       }
     },
     "node_modules/@hcengineering/time": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/time/-/time-0.7.0.tgz",
-      "integrity": "sha512-rvYdAed+Sv1TMwG+M/jRv9wDZBFDIWwLHNR/e1sn8f3KAkvUAKsOBDnnFNE7xKYVMsHFJMIN8+x+8csG11dgTw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/time/-/time-0.7.423.tgz",
+      "integrity": "sha512-jW8GVeLlhN0c+9Vq3zvhnrO6BSZnv0mR9WQXErsgPaJS+joAv0rfH74yXtA7ppShnG3uTqf38f5H1b4E9l149A==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/calendar": "^0.7.0",
-        "@hcengineering/contact": "^0.7.0",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/rank": "^0.7.3",
-        "@hcengineering/task": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0"
+        "@hcengineering/calendar": "^0.7.423",
+        "@hcengineering/contact": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/rank": "^0.7.423",
+        "@hcengineering/task": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/tracker": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/tracker/-/tracker-0.7.0.tgz",
-      "integrity": "sha512-7qA9pHxRhczeMXXQgL1GyM8/uqieG9JwzLBsCXvPt7QW2Nto4nda4/7TKkrt+/UUQKDm+1NmQq7/8ipXuPNN7g==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/tracker/-/tracker-0.7.423.tgz",
+      "integrity": "sha512-0WOSN4fDUagVYZJZWOzpYFafXePOARDlcfiTH4vp/qt5cJ8pfvQROuk/5IcR5S0CZUz+Scgcbp1S05cxNf+trw==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/attachment": "^0.7.0",
-        "@hcengineering/chunter": "^0.7.0",
-        "@hcengineering/contact": "^0.7.0",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/tags": "^0.7.0",
-        "@hcengineering/task": "^0.7.0",
-        "@hcengineering/time": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0",
+        "@hcengineering/attachment": "^0.7.423",
+        "@hcengineering/chunter": "^0.7.423",
+        "@hcengineering/contact": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/tags": "^0.7.423",
+        "@hcengineering/task": "^0.7.423",
+        "@hcengineering/time": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423",
         "lexorank": "~1.0.4"
       }
     },
     "node_modules/@hcengineering/ui": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/ui/-/ui-0.7.0.tgz",
-      "integrity": "sha512-sm2T3TIVQtHBMLw94VsRksHyJQ2Xva6p5vEUkVn5CvFrimALohx72iFzBsd7Oz9MYsX0RPZJIe49IONb2GmLBQ==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/ui/-/ui-0.7.423.tgz",
+      "integrity": "sha512-uOSfDG3b69Q6WgzTq62S/tuiobcTZRopxUHxorXsEfO5/iqSqWb4V61eUexmTBCD+3jAEMquqGcNFW956hXcPg==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/analytics": "^0.7.3",
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/theme": "^0.7.0",
+        "@hcengineering/analytics": "^0.7.423",
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/theme": "^0.7.423",
         "autolinker": "4.0.0",
         "blurhash": "^2.0.5",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
         "dompurify": "^3.1.6",
-        "emojibase": "^16.0.0",
-        "emojibase-regex": "^16.0.0",
         "fast-equals": "^5.2.2",
-        "plyr": "^3.7.8",
+        "plyr": "3.7.8",
         "svelte": "^4.2.20"
       }
     },
     "node_modules/@hcengineering/view": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/view/-/view-0.7.0.tgz",
-      "integrity": "sha512-qeqBD4mSHSRUqrLPFHWZ0FUDDeJH4S0DDkosVjfZuHYQ7xjlfWCRMlDpVyKhtmNvkTMnb1GLvHzxKxe1gTkl/w==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/view/-/view-0.7.423.tgz",
+      "integrity": "sha512-9UCXavJ3pUnzWiYZPL+czdfa6PxkGtknub2uaiN6T7pCMjyMZNPh3AoR4c48HDUeO14njoYrb7CzKeCzhYNCMQ==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423"
       }
     },
     "node_modules/@hcengineering/workbench": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hcengineering/workbench/-/workbench-0.7.0.tgz",
-      "integrity": "sha512-rhFenp84Mq322phsk7DDkiHVbySaXYizzGME3IIGG5BKkkVndwPXXQpAp9lZ1V6/FOI/jQTE5vwh2jv+ioxGyw==",
+      "version": "0.7.423",
+      "resolved": "https://registry.npmjs.org/@hcengineering/workbench/-/workbench-0.7.423.tgz",
+      "integrity": "sha512-YFTPPikH/QNv4C0dgnwAZkRohsZTJVrikGbeVHggSr+6J+AeFgmO26/RBTOVPydTu4ZYqXfNOJozAcRBTgVO7w==",
       "inBundle": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@hcengineering/core": "^0.7.3",
-        "@hcengineering/notification": "^0.7.0",
-        "@hcengineering/platform": "^0.7.3",
-        "@hcengineering/preference": "^0.7.0",
-        "@hcengineering/ui": "^0.7.0",
-        "@hcengineering/view": "^0.7.0"
+        "@hcengineering/core": "^0.7.423",
+        "@hcengineering/notification": "^0.7.423",
+        "@hcengineering/platform": "^0.7.423",
+        "@hcengineering/preference": "^0.7.423",
+        "@hcengineering/ui": "^0.7.423",
+        "@hcengineering/view": "^0.7.423"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1167,9 +1181,9 @@
       "license": "MIT"
     },
     "node_modules/@tiptap/core": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.1.tgz",
-      "integrity": "sha512-nkerkl8syHj44ZzAB7oA2GPmmZINKBKCa79FuNvmGJrJ4qyZwlkDzszud23YteFZEytbc87kVd/fP76ROS6sLg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
+      "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1181,9 +1195,9 @@
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.27.1.tgz",
-      "integrity": "sha512-QrUX3muElDrNjKM3nqCSAtm3H3pT33c6ON8kwRiQboOAjT/9D57Cs7XEVY7r6rMaJPeKztrRUrNVF9w/w/6B0A==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.27.2.tgz",
+      "integrity": "sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1195,9 +1209,9 @@
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.27.1.tgz",
-      "integrity": "sha512-g4l4p892x/r7mhea8syp3fNYODxsDrimgouQ+q4DKXIgQmm5+uNhyuEPexP3I8TFNXqQ4DlMNFoM9yCqk97etQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.27.2.tgz",
+      "integrity": "sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1209,9 +1223,9 @@
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.27.1.tgz",
-      "integrity": "sha512-5FmnfXkJ76wN4EbJNzBhAlmQxho8yEMIJLchTGmXdsD/n/tsyVVtewnQYaIOj/Z7naaGySTGDmjVtLgTuQ+Sxw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.27.2.tgz",
+      "integrity": "sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1223,9 +1237,9 @@
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.27.1.tgz",
-      "integrity": "sha512-i65wUGJevzBTIIUBHBc1ggVa27bgemvGl/tY1/89fEuS/0Xmre+OQjw8rCtSLevoHSiYYLgLRlvjtUSUhE4kgg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.27.2.tgz",
+      "integrity": "sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1237,9 +1251,9 @@
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.1.tgz",
-      "integrity": "sha512-wCI5VIOfSAdkenCWFvh4m8FFCJ51EOK+CUmOC/PWUjyo2Dgn8QC8HMi015q8XF7886T0KvYVVoqxmxJSUDAYNg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.2.tgz",
+      "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1252,9 +1266,9 @@
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.27.1.tgz",
-      "integrity": "sha512-NtJzJY7Q/6XWjpOm5OXKrnEaofrcc1XOTYlo/SaTwl8k2bZo918Vl0IDBWhPVDsUN7kx767uHwbtuQZ+9I82hA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.27.2.tgz",
+      "integrity": "sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1266,9 +1280,9 @@
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.27.1.tgz",
-      "integrity": "sha512-3MBQRGHHZ0by3OT0CWbLKS7J3PH9PpobrXjmIR7kr0nde7+bHqxXiVNuuIf501oKU9rnEUSedipSHkLYGkmfsA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.27.2.tgz",
+      "integrity": "sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1281,9 +1295,9 @@
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.27.1.tgz",
-      "integrity": "sha512-A9e1jr+jGhDWzNSXtIO6PYVYhf5j/udjbZwMja+wCE/3KvZU9V3IrnGKz1xNW+2Q2BDOe1QO7j5uVL9ElR6nTA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.27.2.tgz",
+      "integrity": "sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1296,9 +1310,9 @@
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.27.1.tgz",
-      "integrity": "sha512-W4hHa4Io6QCTwpyTlN6UAvqMIQ7t56kIUByZhyY9EWrg/+JpbfpxE1kXFLPB4ZGgwBknFOw+e4bJ1j3oAbTJFw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.27.2.tgz",
+      "integrity": "sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1310,9 +1324,9 @@
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.27.1.tgz",
-      "integrity": "sha512-6xoC7igZlW1EmnQ5WVH9IL7P1nCQb3bBUaIDLvk7LbweEogcTUECI4Xg1vxMOVmj9tlDe1I4BsgfcKpB5KEsZw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.27.2.tgz",
+      "integrity": "sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1324,9 +1338,9 @@
       }
     },
     "node_modules/@tiptap/extension-highlight": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-2.27.1.tgz",
-      "integrity": "sha512-ntuYX09tvHQE/R/8WbTOxbFuQhRr2jhTkKz/gLwDD2o8IhccSy3f0nm+mVmVamKQnbsBBbLohojd5IGOnX9f1A==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-2.27.2.tgz",
+      "integrity": "sha512-ZjlktDdMjruMJFAVz0TbQf0v92Jqkc7Ri1iZJqBXuLid+r+GxUzl2CVAV7qq5yagkGQgvAG+WGsMk880HgR3MA==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1338,9 +1352,9 @@
       }
     },
     "node_modules/@tiptap/extension-history": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.27.1.tgz",
-      "integrity": "sha512-K8PHC9gegSAt0wzSlsd4aUpoEyIJYOmVVeyniHr1P1mIblW1KYEDbRGbDlrLALTyUEfMcBhdIm8zrB9X2Nihvg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.27.2.tgz",
+      "integrity": "sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1353,9 +1367,9 @@
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.27.1.tgz",
-      "integrity": "sha512-WxXWGEEsqDmGIF2o9av+3r9Qje4CKrqrpeQY6aRO5bxvWX9AabQCfasepayBok6uwtvNzh3Xpsn9zbbSk09dNA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.27.2.tgz",
+      "integrity": "sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1368,9 +1382,9 @@
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.27.1.tgz",
-      "integrity": "sha512-rcm0GyniWW0UhcNI9+1eIK64GqWQLyIIrWGINslvqSUoBc+WkfocLvv4CMpRkzKlfsAxwVIBuH2eLxHKDtAREA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.27.2.tgz",
+      "integrity": "sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1382,9 +1396,9 @@
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.27.1.tgz",
-      "integrity": "sha512-cCwWPZsnVh9MXnGOqSIRXPPuUixRDK8eMN2TvqwbxUBb1TU7b/HtNvfMU4tAOqAuMRJ0aJkFuf3eB0Gi8LVb1g==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.27.2.tgz",
+      "integrity": "sha512-bnP61qkr0Kj9Cgnop1hxn2zbOCBzNtmawxr92bVTOE31fJv6FhtCnQiD6tuPQVGMYhcmAj7eihtvuEMFfqEPcQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1400,9 +1414,9 @@
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.27.1.tgz",
-      "integrity": "sha512-dtsxvtzxfwOJP6dKGf0vb2MJAoDF2NxoiWzpq0XTvo7NGGYUHfuHjX07Zp0dYqb4seaDXjwsi5BIQUOp3+WMFQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.27.2.tgz",
+      "integrity": "sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1414,9 +1428,9 @@
       }
     },
     "node_modules/@tiptap/extension-mention": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-2.27.1.tgz",
-      "integrity": "sha512-8qwPIum0rMK/7BaHEN0+M/VkUn00LqhqyRO8JdC/EBVrUBgxKTQsUhIhSstgVAYzD1w7cCUfTFX4bYu9lcFMEQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-2.27.2.tgz",
+      "integrity": "sha512-uHxVf8RISscb4xgCEJmDSNcFQmzlBTKJh7fp2QAXWIF4Xtrg3zD08PIXUvvHapoluGD9OdBugW4YCu1PJ3xWNw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1430,9 +1444,9 @@
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.27.1.tgz",
-      "integrity": "sha512-U1/sWxc2TciozQsZjH35temyidYUjvroHj3PUPzPyh19w2fwKh1NSbFybWuoYs6jS3XnMSwnM2vF52tOwvfEmA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.27.2.tgz",
+      "integrity": "sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1444,9 +1458,9 @@
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.27.1.tgz",
-      "integrity": "sha512-R3QdrHcUdFAsdsn2UAIvhY0yWyHjqGyP/Rv8RRdN0OyFiTKtwTPqreKMHKJOflgX4sMJl/OpHTpNG1Kaf7Lo2A==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.27.2.tgz",
+      "integrity": "sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1458,9 +1472,37 @@
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.27.1.tgz",
-      "integrity": "sha512-S9I//K8KPgfFTC5I5lorClzXk0g4lrAv9y5qHzHO5EOWt7AFl0YTg2oN8NKSIBK4bHRnPIrjJJKv+dDFnUp5jQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.27.2.tgz",
+      "integrity": "sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-subscript": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-2.27.2.tgz",
+      "integrity": "sha512-x2Oz7hrI4KvzzB9pWChFRm6JnKdYAUQDyrlSROngtzXT7VpNQNoD5s8OlICzDeNsaRKzhR8omIz2z17S1VB48g==",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-superscript": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-2.27.2.tgz",
+      "integrity": "sha512-VTGJDuNqdesibSVW94Q71VaGVGr/bwBppdaNLn7k6beOegALfIH7ncArlkD/eihOlJ2qaWiT7FoWNLTb/Fdv1w==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1472,9 +1514,9 @@
       }
     },
     "node_modules/@tiptap/extension-table": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-2.27.1.tgz",
-      "integrity": "sha512-iOoOo0vYFzAogAZlw36DgmFfNM5vOkLqnApm81soO/YWpqtKAvBn+TMY4ss4OMDsOefUzBa6xqOJ0gJR5ZygjA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-2.27.2.tgz",
+      "integrity": "sha512-pDbhOpT5phZkcsyPjGBQlXv0+0hmdrvqHJ+dJjkGcCtlfy2pHiEIhmIItOFagc7wXy8G9iUFZ9Jie4zvDf+brg==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1487,9 +1529,9 @@
       }
     },
     "node_modules/@tiptap/extension-table-cell": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-2.27.1.tgz",
-      "integrity": "sha512-VowNmz1kub2qfntWkU8jGA6DoCl9xjJBWSypuQIeiN/IRId3BMrJodT26pTNJ3ChDMtYaanWaUvYqckRxgTC2A==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-2.27.2.tgz",
+      "integrity": "sha512-9Lk46MjZMFzVZfOj9Kd7VgC6Odt6vmEhlCYVumErShUY7EkFqCw3b2IYoUtQkntfOEx/Afnhff/okNQwPsJeUA==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1501,9 +1543,9 @@
       }
     },
     "node_modules/@tiptap/extension-table-header": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-2.27.1.tgz",
-      "integrity": "sha512-lSbGB6kBp/sTVzAWl4v7v7ztL5XU3aTdlS7FhfGjpdsxd4zPKYG8kx+Uxgq25W9/BlCbnqHnO0poAMfOlspDQw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-2.27.2.tgz",
+      "integrity": "sha512-ZEb6lbG0NbbodWLV0b4BS/QrDIPlUbCcuOsUxzqVvlMUY1Vg6Fj6fKwLaBcsIUDHi8sxZDBEgYEDw3BR/zcO6A==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1515,9 +1557,9 @@
       }
     },
     "node_modules/@tiptap/extension-table-row": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-2.27.1.tgz",
-      "integrity": "sha512-3xtlmZ6NWDi5a42gK0qQQTeBUpJ2j1o7qyXTFkhQaJAeIFEqsemgSRhgXZxbwSmQQZsPJ/86KWBNVkT0FaRFDw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-2.27.2.tgz",
+      "integrity": "sha512-Nw9+tA56Y5HtLVP01NGCZSUuTQhJPtfK9OfmDgGgcxynn2cRVdEtj+9FNZqRhQ1iRVaAI+Rd4xRvX9qYePMOxw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1529,9 +1571,9 @@
       }
     },
     "node_modules/@tiptap/extension-task-item": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-item/-/extension-task-item-2.27.1.tgz",
-      "integrity": "sha512-vaEtdos+9jApD6yRfD6F/xShikiZFHi7I0nswAmGKT/kE1wmHCUxme8OFMe7642e2OK0lqgHsUaOLxP/0nZJ5A==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-item/-/extension-task-item-2.27.2.tgz",
+      "integrity": "sha512-ZBSqj/dygB/Rp5K9qOxRVwASTZCmKVoTq8C59KvMgD/aFjJxhq/w2dZaWkCUEXEep+NmvJqo0kfeAEMY5UDnGg==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1544,9 +1586,9 @@
       }
     },
     "node_modules/@tiptap/extension-task-list": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-list/-/extension-task-list-2.27.1.tgz",
-      "integrity": "sha512-KRlYOZ6kdURvAspUrLVsC7mLkVW2DYhpj+7QxH7gVDZuAuoPUEmpJVcBVPq7GhPF9PccaRLru+n1Ege5VqvZ+Q==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-list/-/extension-task-list-2.27.2.tgz",
+      "integrity": "sha512-5nupAewdzZ9F3599oAcaK0WkDH04wdACAVBPM4zG7InlIpkbho3txB7zWmm64OxfhCMIMGKiXY1q0bw9i0QBGQ==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1558,9 +1600,9 @@
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.27.1.tgz",
-      "integrity": "sha512-a4GCT+GZ9tUwl82F4CEum9/+WsuW0/De9Be/NqrMmi7eNfAwbUTbLCTFU0gEvv25WMHCoUzaeNk/qGmzeVPJ1Q==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.27.2.tgz",
+      "integrity": "sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1600,9 +1642,9 @@
       }
     },
     "node_modules/@tiptap/extension-typography": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-typography/-/extension-typography-2.27.1.tgz",
-      "integrity": "sha512-jAZU5IuWH9CtZlolQ1gRhV+bT75s19SXjadQwkk18gMMiapcaIVVTxUDWY6ycv9ge4cjRoaP3lqBviW3cGqhOA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-typography/-/extension-typography-2.27.2.tgz",
+      "integrity": "sha512-NSyqDa8PlAZoVRfTWQuxueTZ6ftOD72EV7UKVpftf3C+Heme727mvwl1YHMnagOlqVoxBhFOrl9CnSs/q5uayQ==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1614,9 +1656,9 @@
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.27.1.tgz",
-      "integrity": "sha512-fPTmfJFAQWg1O/os1pYSPVdtvly6eW/w5sDofG7pre+bdQUN+8s1cZYelSuj/ltNVioRaB2Ws7tvNgnHL0aAJQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.27.2.tgz",
+      "integrity": "sha512-gPOsbAcw1S07ezpAISwoO8f0RxpjcSH7VsHEFDVuXm4ODE32nhvSinvHQjv2icRLOXev+bnA7oIBu7Oy859gWQ==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1628,9 +1670,9 @@
       }
     },
     "node_modules/@tiptap/html": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-2.27.1.tgz",
-      "integrity": "sha512-5iPo36g4nbBVoEVBQb6my4KNpNzu38gtCFXIIlAJdAZQvPs+XC8TkrnGK/G4UGpwBXCuQjSQm0iyn4znmQPDsw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-2.27.2.tgz",
+      "integrity": "sha512-WiZgAvFjUprjyAczxAHLN9k++w7klwsCJ7EJDljtW/QXQ476Q0GqNtaHG4WRuW25cBH7c7AWZFptALeak2OE4Q==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1646,9 +1688,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.1.tgz",
-      "integrity": "sha512-ijKo3+kIjALthYsnBmkRXAuw2Tswd9gd7BUR5OMfIcjGp8v576vKxOxrRfuYiUM78GPt//P0sVc1WV82H5N0PQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
+      "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1677,33 +1719,33 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.27.1.tgz",
-      "integrity": "sha512-uQQlP0Nmn9eq19qm8YoOeloEfmcGbPpB1cujq54Q6nPgxaBozR7rE7tXbFTinxRW2+Hr7XyNWhpjB7DMNkdU2Q==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.27.2.tgz",
+      "integrity": "sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.27.1",
-        "@tiptap/extension-blockquote": "^2.27.1",
-        "@tiptap/extension-bold": "^2.27.1",
-        "@tiptap/extension-bullet-list": "^2.27.1",
-        "@tiptap/extension-code": "^2.27.1",
-        "@tiptap/extension-code-block": "^2.27.1",
-        "@tiptap/extension-document": "^2.27.1",
-        "@tiptap/extension-dropcursor": "^2.27.1",
-        "@tiptap/extension-gapcursor": "^2.27.1",
-        "@tiptap/extension-hard-break": "^2.27.1",
-        "@tiptap/extension-heading": "^2.27.1",
-        "@tiptap/extension-history": "^2.27.1",
-        "@tiptap/extension-horizontal-rule": "^2.27.1",
-        "@tiptap/extension-italic": "^2.27.1",
-        "@tiptap/extension-list-item": "^2.27.1",
-        "@tiptap/extension-ordered-list": "^2.27.1",
-        "@tiptap/extension-paragraph": "^2.27.1",
-        "@tiptap/extension-strike": "^2.27.1",
-        "@tiptap/extension-text": "^2.27.1",
-        "@tiptap/extension-text-style": "^2.27.1",
-        "@tiptap/pm": "^2.27.1"
+        "@tiptap/core": "^2.27.2",
+        "@tiptap/extension-blockquote": "^2.27.2",
+        "@tiptap/extension-bold": "^2.27.2",
+        "@tiptap/extension-bullet-list": "^2.27.2",
+        "@tiptap/extension-code": "^2.27.2",
+        "@tiptap/extension-code-block": "^2.27.2",
+        "@tiptap/extension-document": "^2.27.2",
+        "@tiptap/extension-dropcursor": "^2.27.2",
+        "@tiptap/extension-gapcursor": "^2.27.2",
+        "@tiptap/extension-hard-break": "^2.27.2",
+        "@tiptap/extension-heading": "^2.27.2",
+        "@tiptap/extension-history": "^2.27.2",
+        "@tiptap/extension-horizontal-rule": "^2.27.2",
+        "@tiptap/extension-italic": "^2.27.2",
+        "@tiptap/extension-list-item": "^2.27.2",
+        "@tiptap/extension-ordered-list": "^2.27.2",
+        "@tiptap/extension-paragraph": "^2.27.2",
+        "@tiptap/extension-strike": "^2.27.2",
+        "@tiptap/extension-text": "^2.27.2",
+        "@tiptap/extension-text-style": "^2.27.2",
+        "@tiptap/pm": "^2.27.2"
       },
       "funding": {
         "type": "github",
@@ -1711,9 +1753,9 @@
       }
     },
     "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-text-style": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.27.1.tgz",
-      "integrity": "sha512-NagQ9qLk0Ril83gfrk+C65SvTqPjL3WVnLF2arsEVnCrxcx3uDOvdJW67f/K5HEwEHsoqJ4Zq9Irco/koXrOXA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.27.2.tgz",
+      "integrity": "sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -1725,9 +1767,9 @@
       }
     },
     "node_modules/@tiptap/suggestion": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-2.27.1.tgz",
-      "integrity": "sha512-yTy75ZMYgVWM18cl7YxLqMJ7TorQTGysSd1aKmBA9qd8uzYlvLMmHKE9qBDxM9HXODBz1DA/BLLm9esv2enmFw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-2.27.2.tgz",
+      "integrity": "sha512-dQyvCIg0hcAVeh4fCIVCxogvbp+bF+GpbUb8sNlgnGrmHXnapGxzkvrlHnvneXZxLk/j7CxmBPKJNnm4Pbx4zw==",
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -2055,9 +2097,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
@@ -2270,9 +2312,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "inBundle": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -2313,31 +2355,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
-    },
-    "node_modules/emojibase": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-16.0.0.tgz",
-      "integrity": "sha512-Nw2m7JLIO4Ou2X/yZPRNscHQXVbbr6SErjkJ7EooG7MbR3yDZszCv9KTizsXFc7yZl0n3WF+qUKIC/Lw6H9xaQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/milesjohnson"
-      }
-    },
-    "node_modules/emojibase-regex": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/emojibase-regex/-/emojibase-regex-16.0.0.tgz",
-      "integrity": "sha512-ZMp31BkzBWNW+T73of6NURL6nXQa5GkfKneOkr3cEwBDVllbW/2nuva7NO0J3RjaQ07+SZQNgPTGZ4JlIhmM2Q==",
-      "inBundle": true,
-      "license": "MIT",
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/milesjohnson"
-      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -3260,9 +3277,19 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3270,9 +3297,9 @@
       }
     },
     "node_modules/linkifyjs": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "inBundle": true,
       "license": "MIT"
     },
@@ -3326,15 +3353,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -3435,9 +3472,9 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.8.tgz",
-      "integrity": "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==",
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
       "inBundle": true,
       "license": "MIT",
       "optionalDependencies": {
@@ -3682,17 +3719,17 @@
       }
     },
     "node_modules/plyr": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/plyr/-/plyr-3.8.3.tgz",
-      "integrity": "sha512-0+iI5uw0WRvtKBpgPCkmQQv7ucHVQKTEo6UFJjgJ8cy/JZhy0dQqshHQVitHXV6l2O3MzhgnuvQ95VSkWcWeSw==",
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/plyr/-/plyr-3.7.8.tgz",
+      "integrity": "sha512-yG/EHDobwbB/uP+4Bm6eUpJ93f8xxHjjk2dYcD1Oqpe1EcuQl5tzzw9Oq+uVAzd2lkM11qZfydSiyIpiB8pgdA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "core-js": "^3.45.1",
+        "core-js": "^3.26.1",
         "custom-event-polyfill": "^1.0.7",
-        "loadjs": "^4.3.0",
+        "loadjs": "^4.2.0",
         "rangetouch": "^2.0.1",
-        "url-polyfill": "^1.1.13"
+        "url-polyfill": "^1.1.12"
       }
     },
     "node_modules/prelude-ls": {
@@ -3706,9 +3743,9 @@
       }
     },
     "node_modules/prosemirror-changeset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.3.1.tgz",
-      "integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3763,9 +3800,9 @@
       }
     },
     "node_modules/prosemirror-gapcursor": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.0.tgz",
-      "integrity": "sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3811,9 +3848,9 @@
       }
     },
     "node_modules/prosemirror-markdown": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
-      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3823,9 +3860,9 @@
       }
     },
     "node_modules/prosemirror-menu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.5.tgz",
-      "integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.2.tgz",
+      "integrity": "sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3836,9 +3873,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
+      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3910,9 +3947,9 @@
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
-      "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3920,9 +3957,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.41.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
-      "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "model-context-protocol",
     "issue-tracker",
     "rest-api",
+    "codex",
     "claude",
     "ai-agent"
   ],
@@ -44,12 +45,12 @@
     "version:sync": "node -e \"const{readFileSync:r,writeFileSync:w}=require('fs');const v=r('VERSION','utf-8').trim();const f='package.json';const j=JSON.parse(r(f,'utf-8'));j.version=v;w(f,JSON.stringify(j,null,2)+'\\n');console.log('Synced version '+v+' to package.json')\""
   },
   "dependencies": {
-    "@hcengineering/api-client": "^0.7.3",
-    "@hcengineering/chunter": "^0.7.0",
-    "@hcengineering/core": "^0.7.4",
-    "@hcengineering/tags": "^0.7.0",
-    "@hcengineering/task": "^0.7.0",
-    "@hcengineering/tracker": "^0.7.0",
+    "@hcengineering/api-client": "^0.7.423",
+    "@hcengineering/chunter": "^0.7.423",
+    "@hcengineering/core": "^0.7.423",
+    "@hcengineering/tags": "^0.7.423",
+    "@hcengineering/task": "^0.7.423",
+    "@hcengineering/tracker": "^0.7.423",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "jsdom": "^29.0.0"
   },

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -47,10 +47,10 @@ for (const pkg of hulyNeeded) {
   }
 }
 
-// Strip @hcengineering/* deps from bundled packages so npm doesn't try
-// to fetch them from the registry (some published versions use workspace:
-// protocol which npm can't resolve). All needed packages are already
-// co-located in node_modules so Node.js resolves them via the file system.
+// Strip @hcengineering/* deps from bundled packages so the published tarball
+// stays self-contained and npm does not fetch unused SDK/frontend packages.
+// All needed packages are already co-located in node_modules, so Node.js
+// resolves them via the file system.
 const hulySet = new Set(hulyNeeded);
 for (const pkg of hulyNeeded) {
   const pkgJsonPath = join(tmp, 'node_modules', '@hcengineering', pkg, 'package.json');
@@ -107,8 +107,8 @@ cpSync(tgzSrc, tgzDst);
 
 // Rewrite the tarball's package.json to remove @hcengineering/* from
 // dependencies. npm resolves deps from registry metadata BEFORE extracting
-// bundled packages — keeping them in dependencies causes npm to fetch
-// Huly SDK versions with broken workspace: protocol references.
+// bundled packages; keeping them here makes npm fetch SDK packages that are
+// already bundled and may pull in unused frontend dependencies.
 const rewriteDir = join(root, '.pack-rewrite');
 if (existsSync(rewriteDir)) rmSync(rewriteDir, { recursive: true });
 mkdirSync(rewriteDir, { recursive: true });

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -8,6 +8,7 @@ export const HULY_TOKEN = process.env.HULY_TOKEN;
 export const HULY_EMAIL = process.env.HULY_EMAIL;
 export const HULY_PASSWORD = process.env.HULY_PASSWORD;
 export const HULY_WORKSPACE = process.env.HULY_WORKSPACE;
+export const HULY_PROJECT = process.env.HULY_PROJECT;
 export const HULY_CREDS = HULY_TOKEN
   ? { token: HULY_TOKEN }
   : { email: HULY_EMAIL, password: HULY_PASSWORD };

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -6,11 +6,41 @@
  *   node src/index.mjs                          → Start MCP stdio server
  *   node src/index.mjs --get-token              → Print JWT (uses HULY_EMAIL/HULY_PASSWORD env vars)
  *   node src/index.mjs --get-token -e EMAIL -p PASS -u URL
+ *   node src/index.mjs --init-codex             → Generate project .codex/config.toml
+ *   node src/index.mjs --init-claude            → Generate project .mcp.json
+ *   node src/index.mjs --init-all               → Generate Claude and Codex project config
  */
 
 const args = process.argv.slice(2);
 
-if (args.includes('--get-token')) {
+if (args.includes('--init-all')) {
+  const { initAllConfigs } = await import('./initCodex.mjs');
+  try {
+    const result = initAllConfigs(args.filter(arg => arg !== '--init-all'));
+    console.log(result.message);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+} else if (args.includes('--init-claude')) {
+  const { initClaudeConfig } = await import('./initCodex.mjs');
+  try {
+    const result = initClaudeConfig(args.filter(arg => arg !== '--init-claude'));
+    console.log(result.message);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+} else if (args.includes('--init-codex')) {
+  const { initCodexConfig } = await import('./initCodex.mjs');
+  try {
+    const result = initCodexConfig(args.filter(arg => arg !== '--init-codex'));
+    console.log(result.message);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+} else if (args.includes('--get-token')) {
   const flag = (name) => {
     const i = args.indexOf(name);
     return i !== -1 && i + 1 < args.length ? args[i + 1] : undefined;

--- a/src/initCodex.mjs
+++ b/src/initCodex.mjs
@@ -1,0 +1,281 @@
+/**
+ * Helpers for generating project-scoped MCP configuration.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join, parse, resolve } from 'path';
+
+const DEFAULT_SERVER_NAME = 'huly';
+
+function usage(command = 'all') {
+  const commands = {
+    codex: 'huly-mcp-server --init-codex [--workspace <slug>] [--project <identifier>] [--server-name <name>] [--force]',
+    claude: 'huly-mcp-server --init-claude --workspace <slug> [--project <identifier>] [--server-name <name>] [--force]',
+    all: 'huly-mcp-server --init-all --workspace <slug> [--project <identifier>] [--server-name <name>] [--force]'
+  };
+  return [
+    `Usage: ${commands[command] || commands.all}`,
+    '',
+    'Secrets are referenced from the user environment.',
+    'HULY_WORKSPACE is written literally per project.',
+    'HULY_PROJECT is optional and written only when --project is provided or inferable.'
+  ].join('\n');
+}
+
+function flagValue(args, names) {
+  for (const name of names) {
+    const i = args.indexOf(name);
+    if (i !== -1 && i + 1 < args.length) return args[i + 1];
+  }
+  return undefined;
+}
+
+function hasFlag(args, names) {
+  return names.some(name => args.includes(name));
+}
+
+function findUp(filename, startDir = process.cwd()) {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = join(dir, filename);
+    if (existsSync(candidate)) return candidate;
+
+    const parent = dirname(dir);
+    if (parent === dir || parse(dir).root === dir) return null;
+    dir = parent;
+  }
+}
+
+function isEnvReference(value) {
+  return typeof value === 'string' && /^\$\{[A-Z0-9_]+\}$/.test(value);
+}
+
+function readHulyMcpConfig(mcpPath, serverName) {
+  const raw = readFileSync(mcpPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  const servers = parsed.mcpServers || {};
+  return servers[serverName] || servers[DEFAULT_SERVER_NAME] || null;
+}
+
+function readMcpJson(mcpPath) {
+  if (!existsSync(mcpPath)) return { mcpServers: {} };
+  const raw = readFileSync(mcpPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function inferLiteralEnv(hulyConfig, key, explicitValue) {
+  if (explicitValue) return explicitValue;
+
+  const value = hulyConfig?.env?.[key];
+  if (typeof value === 'string' && value.length > 0 && !isEnvReference(value)) {
+    return value;
+  }
+
+  return null;
+}
+
+function inferEnvVars(hulyConfig) {
+  const env = hulyConfig?.env || {};
+  const vars = [];
+
+  for (const key of ['HULY_URL', 'HULY_TOKEN', 'HULY_EMAIL', 'HULY_PASSWORD']) {
+    const value = env[key];
+    if (isEnvReference(value)) {
+      const name = value.slice(2, -1);
+      if (!vars.includes(name)) vars.push(name);
+    }
+  }
+
+  return vars.length > 0 ? vars : ['HULY_URL', 'HULY_TOKEN'];
+}
+
+function tomlString(value) {
+  return JSON.stringify(value);
+}
+
+function renderCodexConfig({ serverName, envVars, workspace, project }) {
+  const args = ['-y', '@bgx4k3p/huly-mcp-server'];
+  const lines = [
+    `[mcp_servers.${serverName}]`,
+    'command = "npx"',
+    `args = [${args.map(tomlString).join(', ')}]`,
+    `env_vars = [${envVars.map(tomlString).join(', ')}]`,
+    'startup_timeout_sec = 20',
+    'tool_timeout_sec = 120',
+    '',
+    `[mcp_servers.${serverName}.env]`,
+    `HULY_WORKSPACE = ${tomlString(workspace)}`
+  ];
+
+  if (project) {
+    lines.push(`HULY_PROJECT = ${tomlString(project)}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function codexHeaderName(line) {
+  const match = line.trim().match(/^\[([^\]]+)\]$/);
+  return match?.[1] || null;
+}
+
+function isCodexServerHeader(header, serverName) {
+  const prefix = `mcp_servers.${serverName}`;
+  return header === prefix || header.startsWith(`${prefix}.`);
+}
+
+function hasCodexServerConfig(content, serverName) {
+  return content
+    .split(/\r?\n/)
+    .some(line => {
+      const header = codexHeaderName(line);
+      return header && isCodexServerHeader(header, serverName);
+    });
+}
+
+function removeCodexServerConfig(content, serverName) {
+  const lines = content.split(/\r?\n/);
+  const kept = [];
+  let skipping = false;
+
+  for (const line of lines) {
+    const header = codexHeaderName(line);
+    if (header) {
+      skipping = isCodexServerHeader(header, serverName);
+    }
+
+    if (!skipping) kept.push(line);
+  }
+
+  return kept.join('\n').trimEnd();
+}
+
+function mergeCodexConfig(existing, serverName, serverConfig, force) {
+  if (!existing.trim()) return serverConfig;
+
+  const hasServer = hasCodexServerConfig(existing, serverName);
+  if (hasServer && !force) {
+    throw new Error(`.codex/config.toml already has mcp_servers.${serverName}. Re-run with --force to replace it.`);
+  }
+
+  const base = hasServer ? removeCodexServerConfig(existing, serverName) : existing.trimEnd();
+  return `${base}\n\n${serverConfig}`;
+}
+
+function renderClaudeServer({ workspace, project }) {
+  const env = {
+    HULY_URL: '${HULY_URL}',
+    HULY_TOKEN: '${HULY_TOKEN}',
+    HULY_WORKSPACE: workspace
+  };
+
+  if (project) {
+    env.HULY_PROJECT = project;
+  }
+
+  return {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@bgx4k3p/huly-mcp-server'],
+    env
+  };
+}
+
+function projectDirFromCwd(cwd) {
+  const mcpPath = findUp('.mcp.json', cwd);
+  return mcpPath ? dirname(mcpPath) : resolve(cwd);
+}
+
+function existingHulyConfig(projectDir, serverName) {
+  const mcpPath = join(projectDir, '.mcp.json');
+  return existsSync(mcpPath) ? readHulyMcpConfig(mcpPath, serverName) : null;
+}
+
+function resolveWorkspaceAndProject(args, projectDir, serverName) {
+  const hulyConfig = existingHulyConfig(projectDir, serverName);
+  const workspace = inferLiteralEnv(hulyConfig, 'HULY_WORKSPACE', flagValue(args, ['--workspace', '-w']));
+  const project = inferLiteralEnv(hulyConfig, 'HULY_PROJECT', flagValue(args, ['--project', '-p']));
+
+  if (!workspace) {
+    throw new Error('Could not determine HULY_WORKSPACE. Re-run with --workspace <slug>.');
+  }
+
+  return { hulyConfig, workspace, project };
+}
+
+export function initCodexConfig(args = process.argv.slice(2), cwd = process.cwd()) {
+  if (hasFlag(args, ['--help', '-h'])) {
+    return { ok: true, message: usage('codex') };
+  }
+
+  const serverName = flagValue(args, ['--server-name']) || DEFAULT_SERVER_NAME;
+  const force = hasFlag(args, ['--force']);
+  const projectDir = projectDirFromCwd(cwd);
+  const { hulyConfig, workspace, project } = resolveWorkspaceAndProject(args, projectDir, serverName);
+
+  const codexDir = join(projectDir, '.codex');
+  const configPath = join(codexDir, 'config.toml');
+
+  mkdirSync(codexDir, { recursive: true });
+  const serverConfig = renderCodexConfig({
+    serverName,
+    envVars: inferEnvVars(hulyConfig),
+    workspace,
+    project
+  });
+  const existing = existsSync(configPath) ? readFileSync(configPath, 'utf8') : '';
+  const content = mergeCodexConfig(existing, serverName, serverConfig, force);
+  writeFileSync(configPath, content, 'utf8');
+
+  return {
+    ok: true,
+    path: configPath,
+    message: `Wrote ${configPath} for Huly workspace "${workspace}".`
+  };
+}
+
+export function initClaudeConfig(args = process.argv.slice(2), cwd = process.cwd()) {
+  if (hasFlag(args, ['--help', '-h'])) {
+    return { ok: true, message: usage('claude') };
+  }
+
+  const serverName = flagValue(args, ['--server-name']) || DEFAULT_SERVER_NAME;
+  const force = hasFlag(args, ['--force']);
+  const projectDir = projectDirFromCwd(cwd);
+  const mcpPath = join(projectDir, '.mcp.json');
+  const parsed = readMcpJson(mcpPath);
+  parsed.mcpServers ||= {};
+
+  const existing = parsed.mcpServers[serverName];
+  const { workspace, project } = resolveWorkspaceAndProject(args, projectDir, serverName);
+  const nextServer = renderClaudeServer({ workspace, project });
+
+  if (existing && !force && JSON.stringify(existing) !== JSON.stringify(nextServer)) {
+    throw new Error(`${mcpPath} already has mcpServers.${serverName}. Re-run with --force to replace it.`);
+  }
+
+  parsed.mcpServers[serverName] = nextServer;
+  writeFileSync(mcpPath, `${JSON.stringify(parsed, null, 2)}\n`, 'utf8');
+
+  return {
+    ok: true,
+    path: mcpPath,
+    message: `Wrote ${mcpPath} for Huly workspace "${workspace}".`
+  };
+}
+
+export function initAllConfigs(args = process.argv.slice(2), cwd = process.cwd()) {
+  if (hasFlag(args, ['--help', '-h'])) {
+    return { ok: true, message: usage('all') };
+  }
+
+  const claude = initClaudeConfig(args, cwd);
+  const codex = initCodexConfig(args, cwd);
+
+  return {
+    ok: true,
+    paths: [claude.path, codex.path],
+    message: [claude.message, codex.message].join('\n')
+  };
+}

--- a/src/mcp.mjs
+++ b/src/mcp.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Huly MCP Server - stdio transport entry point for Claude Code.
+ * Huly MCP Server - stdio transport entry point for local MCP clients.
  *
  * Uses the shared MCP server factory from mcpShared.mjs.
  *

--- a/src/mcpShared.mjs
+++ b/src/mcpShared.mjs
@@ -16,12 +16,38 @@ import {
 import { createRequire } from 'module';
 import { pool } from './pool.mjs';
 import { accountTools, workspaceTools } from './dispatch.mjs';
-import { HULY_URL, HULY_CREDS } from './config.mjs';
+import { HULY_URL, HULY_TOKEN, HULY_EMAIL, HULY_PASSWORD, HULY_WORKSPACE, HULY_PROJECT, HULY_CREDS } from './config.mjs';
 
 const require = createRequire(import.meta.url);
 const { name: PKG_NAME, version: PKG_VERSION } = require('../package.json');
 
 export { PKG_NAME, PKG_VERSION };
+
+const PROJECT_DEFAULT_TOOLS = new Set([
+  'get_project',
+  'list_issues',
+  'create_issue',
+  'update_project',
+  'delete_project',
+  'archive_project',
+  'batch_create_issues',
+  'summarize_project',
+  'create_issues_from_template',
+  'list_components',
+  'get_component',
+  'create_component',
+  'update_component',
+  'delete_component',
+  'list_milestones',
+  'get_milestone',
+  'create_milestone',
+  'update_milestone',
+  'delete_milestone',
+  'list_statuses',
+  'get_status',
+  'list_task_types',
+  'get_task_type'
+]);
 
 // Optional workspace property added to every tool
 const workspaceProp = {
@@ -47,18 +73,51 @@ const paginationProps = {
 
 export { workspaceProp };
 
+function hulyUrlHost() {
+  try {
+    return new URL(HULY_URL).host;
+  } catch {
+    return HULY_URL || null;
+  }
+}
+
+function authMode() {
+  if (HULY_TOKEN) return 'token';
+  if (HULY_EMAIL && HULY_PASSWORD) return 'email_password';
+  if (HULY_EMAIL || HULY_PASSWORD) return 'incomplete_email_password';
+  return 'none';
+}
+
+function getHulyContext() {
+  return {
+    defaultWorkspace: HULY_WORKSPACE || null,
+    defaultProject: HULY_PROJECT || null,
+    hulyUrlHost: hulyUrlHost(),
+    authMode: authMode(),
+    packageName: PKG_NAME,
+    packageVersion: PKG_VERSION
+  };
+}
+
 /**
  * Route a tool call to the appropriate HulyClient method.
  */
-export async function handleToolCall(name, args) {
+export async function handleToolCall(name, args = {}) {
+  if (name === 'get_huly_context') {
+    return getHulyContext();
+  }
+
   if (accountTools[name]) {
     return await accountTools[name](args, HULY_URL, HULY_CREDS);
   }
 
   if (workspaceTools[name]) {
-    const workspace = args.workspace || process.env.HULY_WORKSPACE;
+    const toolArgs = PROJECT_DEFAULT_TOOLS.has(name) && HULY_PROJECT && !args.project
+      ? { ...args, project: HULY_PROJECT }
+      : args;
+    const workspace = toolArgs.workspace || process.env.HULY_WORKSPACE;
     const client = await pool.getClient(workspace);
-    return await client.withReconnect(() => workspaceTools[name](args, client));
+    return await client.withReconnect(() => workspaceTools[name](toolArgs, client));
   }
 
   throw new Error(`Unknown tool: ${name}`);
@@ -71,7 +130,7 @@ export async function handleToolCall(name, args) {
  */
 export function createMcpServer(capabilities = {}) {
   // Import TOOLS inline to keep this module self-contained
-  const TOOLS = getToolDefinitions();
+  const TOOLS = applyDefaultProject(getToolDefinitions());
 
   const server = new Server(
     { name: PKG_NAME, version: PKG_VERSION },
@@ -185,6 +244,11 @@ export function createMcpServer(capabilities = {}) {
 
 function getToolDefinitions() {
   return [
+    {
+      name: 'get_huly_context',
+      description: 'Return sanitized runtime context for this Huly MCP server: default workspace, default project, Huly URL host, auth mode, package name, and package version. Does not return secrets.',
+      inputSchema: { type: 'object', properties: {}, required: [] }
+    },
     // ── Account & Workspace Management ──────────────────────
     {
       name: 'list_workspaces',
@@ -615,4 +679,30 @@ function getToolDefinitions() {
       inputSchema: { type: 'object', properties: { reportId: { type: 'string', description: 'Time report ID' }, ...workspaceProp }, required: ['reportId'] }
     },
   ];
+}
+
+function applyDefaultProject(tools) {
+  if (!HULY_PROJECT) return tools;
+
+  return tools.map(tool => {
+    if (!PROJECT_DEFAULT_TOOLS.has(tool.name)) return tool;
+
+    const schema = tool.inputSchema;
+    if (!schema?.properties?.project || !schema.required?.includes('project')) return tool;
+
+    return {
+      ...tool,
+      inputSchema: {
+        ...schema,
+        properties: {
+          ...schema.properties,
+          project: {
+            ...schema.properties.project,
+            description: `${schema.properties.project.description} Optional when HULY_PROJECT is set; defaults to "${HULY_PROJECT}".`
+          }
+        },
+        required: schema.required.filter(name => name !== 'project')
+      }
+    };
+  });
 }

--- a/test/initCodex.test.mjs
+++ b/test/initCodex.test.mjs
@@ -1,0 +1,170 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { initAllConfigs, initClaudeConfig, initCodexConfig } from '../src/initCodex.mjs';
+
+function tempProject() {
+  return mkdtempSync('/private/tmp/huly-mcp-init-');
+}
+
+function writeMcp(projectDir, workspaceValue = 'my-workspace') {
+  writeFileSync(join(projectDir, '.mcp.json'), JSON.stringify({
+    mcpServers: {
+      huly: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@bgx4k3p/huly-mcp-server'],
+        env: {
+          HULY_URL: '${HULY_URL}',
+          HULY_TOKEN: '${HULY_TOKEN}',
+          HULY_WORKSPACE: workspaceValue
+        }
+      }
+    }
+  }, null, 2));
+}
+
+describe('initCodexConfig', () => {
+  it('generates project-scoped Codex MCP config from a literal .mcp.json workspace', () => {
+    const projectDir = tempProject();
+    writeMcp(projectDir);
+
+    const result = initCodexConfig([], projectDir);
+    const config = readFileSync(result.path, 'utf8');
+
+    assert.match(config, /\[mcp_servers\.huly\]/);
+    assert.match(config, /command = "npx"/);
+    assert.match(config, /env_vars = \["HULY_URL", "HULY_TOKEN"\]/);
+    assert.match(config, /HULY_WORKSPACE = "my-workspace"/);
+  });
+
+  it('uses --workspace when .mcp.json workspace is an env reference', () => {
+    const projectDir = tempProject();
+    writeMcp(projectDir, '${HULY_WORKSPACE_MYAPP}');
+
+    const result = initCodexConfig(['--workspace', 'my-workspace'], projectDir);
+    const config = readFileSync(result.path, 'utf8');
+
+    assert.match(config, /HULY_WORKSPACE = "my-workspace"/);
+  });
+
+  it('preserves existing Codex config when adding the Huly server', () => {
+    const projectDir = tempProject();
+    writeMcp(projectDir);
+    mkdirSync(join(projectDir, '.codex'));
+    writeFileSync(join(projectDir, '.codex', 'config.toml'), 'model = "test"\n');
+
+    const result = initCodexConfig([], projectDir);
+    const config = readFileSync(result.path, 'utf8');
+
+    assert.match(config, /model = "test"/);
+    assert.match(config, /\[mcp_servers\.huly\]/);
+  });
+
+  it('refuses to replace an existing Codex huly server without --force', () => {
+    const projectDir = tempProject();
+    writeMcp(projectDir);
+    mkdirSync(join(projectDir, '.codex'));
+    writeFileSync(join(projectDir, '.codex', 'config.toml'), [
+      'model = "test"',
+      '',
+      '[mcp_servers.huly]',
+      'command = "old"',
+      ''
+    ].join('\n'));
+
+    assert.throws(
+      () => initCodexConfig([], projectDir),
+      /already has mcp_servers\.huly/
+    );
+  });
+
+  it('replaces only the Codex huly server with --force', () => {
+    const projectDir = tempProject();
+    writeMcp(projectDir);
+    mkdirSync(join(projectDir, '.codex'));
+    writeFileSync(join(projectDir, '.codex', 'config.toml'), [
+      'model = "test"',
+      '',
+      '[mcp_servers.other]',
+      'command = "other"',
+      '',
+      '[mcp_servers.huly]',
+      'command = "old"',
+      '',
+      '[mcp_servers.huly.env]',
+      'HULY_WORKSPACE = "old"',
+      ''
+    ].join('\n'));
+
+    const result = initCodexConfig(['--force'], projectDir);
+    const config = readFileSync(result.path, 'utf8');
+
+    assert.match(config, /model = "test"/);
+    assert.match(config, /\[mcp_servers\.other\]/);
+    assert.doesNotMatch(config, /command = "old"/);
+    assert.match(config, /HULY_WORKSPACE = "my-workspace"/);
+  });
+
+  it('writes optional HULY_PROJECT to Codex config when --project is provided', () => {
+    const projectDir = tempProject();
+
+    const result = initCodexConfig(['--workspace', 'my-workspace', '--project', 'PROJ'], projectDir);
+    const config = readFileSync(result.path, 'utf8');
+
+    assert.match(config, /HULY_WORKSPACE = "my-workspace"/);
+    assert.match(config, /HULY_PROJECT = "PROJ"/);
+  });
+
+  it('creates .mcp.json for Claude while preserving existing servers', () => {
+    const projectDir = tempProject();
+    writeFileSync(join(projectDir, '.mcp.json'), JSON.stringify({
+      mcpServers: {
+        other: {
+          command: 'node',
+          args: ['other-server.js']
+        }
+      }
+    }, null, 2));
+
+    const result = initClaudeConfig(['--workspace', 'my-workspace', '--project', 'PROJ'], projectDir);
+    const parsed = JSON.parse(readFileSync(result.path, 'utf8'));
+
+    assert.ok(parsed.mcpServers.other);
+    assert.deepEqual(parsed.mcpServers.huly, {
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@bgx4k3p/huly-mcp-server'],
+      env: {
+        HULY_URL: '${HULY_URL}',
+        HULY_TOKEN: '${HULY_TOKEN}',
+        HULY_WORKSPACE: 'my-workspace',
+        HULY_PROJECT: 'PROJ'
+      }
+    });
+  });
+
+  it('refuses to replace an existing Claude huly server without --force', () => {
+    const projectDir = tempProject();
+    writeMcp(projectDir);
+
+    assert.throws(
+      () => initClaudeConfig(['--workspace', 'other-workspace'], projectDir),
+      /already has mcpServers\.huly/
+    );
+  });
+
+  it('creates both Claude and Codex config with --init-all helper', () => {
+    const projectDir = tempProject();
+
+    const result = initAllConfigs(['--workspace', 'my-workspace', '--project', 'PROJ'], projectDir);
+    const mcp = JSON.parse(readFileSync(join(projectDir, '.mcp.json'), 'utf8'));
+    const codex = readFileSync(join(projectDir, '.codex', 'config.toml'), 'utf8');
+
+    assert.equal(result.paths.length, 2);
+    assert.equal(mcp.mcpServers.huly.env.HULY_PROJECT, 'PROJ');
+    assert.match(codex, /HULY_PROJECT = "PROJ"/);
+  });
+});

--- a/test/mcpShared.test.mjs
+++ b/test/mcpShared.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.HULY_URL = 'https://huly.example.test';
+process.env.HULY_TOKEN = 'secret-token';
+process.env.HULY_WORKSPACE = 'my-workspace';
+process.env.HULY_PROJECT = 'PROJ';
+
+const { handleToolCall, createMcpServer } = await import('../src/mcpShared.mjs');
+
+describe('MCP shared runtime context', () => {
+  it('returns sanitized Huly context without credentials', async () => {
+    const result = await handleToolCall('get_huly_context', {});
+
+    assert.deepEqual(result, {
+      defaultWorkspace: 'my-workspace',
+      defaultProject: 'PROJ',
+      hulyUrlHost: 'huly.example.test',
+      authMode: 'token',
+      packageName: '@bgx4k3p/huly-mcp-server',
+      packageVersion: result.packageVersion
+    });
+    assert.ok(result.packageVersion);
+    assert.equal(Object.hasOwn(result, 'token'), false);
+    assert.equal(Object.hasOwn(result, 'password'), false);
+  });
+
+  it('handles missing tool arguments for zero-argument tools', async () => {
+    const result = await handleToolCall('get_huly_context');
+
+    assert.equal(result.defaultWorkspace, 'my-workspace');
+    assert.equal(result.defaultProject, 'PROJ');
+  });
+
+  it('advertises get_huly_context in the MCP tool list', async () => {
+    const { TOOLS } = createMcpServer();
+    assert.ok(TOOLS.some(tool => tool.name === 'get_huly_context'));
+  });
+
+  it('makes project optional in project-scoped schemas when HULY_PROJECT is set', async () => {
+    const { TOOLS } = createMcpServer();
+    const getProject = TOOLS.find(tool => tool.name === 'get_project');
+    const createIssue = TOOLS.find(tool => tool.name === 'create_issue');
+
+    assert.ok(!getProject.inputSchema.required.includes('project'));
+    assert.ok(!createIssue.inputSchema.required.includes('project'));
+    assert.match(getProject.inputSchema.properties.project.description, /defaults to "PROJ"/);
+    assert.ok(createIssue.inputSchema.required.includes('title'));
+  });
+});


### PR DESCRIPTION
## Summary
- add --init-codex, --init-claude, and --init-all project config helpers
- add get_huly_context plus optional HULY_PROJECT defaults for project-scoped tools
- update README for Codex/Claude project-scoped setup and refresh Huly SDK deps to 0.7.423

## Huly
- HMCP-38
- HMCP-37

## Validation
- npm run lint
- node --test test/initCodex.test.mjs test/mcpShared.test.mjs
- node --check src/initCodex.mjs
- node --check src/mcpShared.mjs
- node --check src/index.mjs
- git diff --check
- npm --cache /private/tmp/npm-cache pack --dry-run
- npm_config_cache=/private/tmp/npm-cache node scripts/pack.mjs from temp mirror (4.2MB tarball)
- HULY_WORKSPACE=coding HULY_TEST_PROJECT=HMCP npm test (ws + rest, 196/196 each transport)

## Notes
The first full npm test run without HULY_WORKSPACE failed because the suite defaulted to a non-listed workspace slug, default. The rerun passed with the explicit HMCP workspace/project.