### PR TITLE
Fix comment markup serialization

### DIFF
--- a/src/client.mjs
+++ b/src/client.mjs
@@ -2378,7 +2378,7 @@ export class HulyClient {
       issue._id,
       tracker.class.Issue,
       'comments',
-      { message: toMarkup(text, format), attachments: 0 },
+      { message: toCollaboratorMarkup(text, format), attachments: 0 },
       commentId
     );
 
@@ -3597,7 +3597,7 @@ export class HulyClient {
     if (!comment) throw new Error(`Comment not found: ${commentId}`);
 
     await client.updateDoc(chunter.class.ChatMessage, project._id, commentId, {
-      message: toMarkup(text, format)
+      message: toCollaboratorMarkup(text, format)
     });
 
     return {

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -232,8 +232,8 @@ export function fromCollaboratorMarkup(markup, format = 'markdown') {
 }
 
 /**
- * Convert text to MarkupContent for non-collaborator fields
- * (milestones, comments, components, projects).
+ * Convert text to MarkupContent for SDK fields that expect MarkupContent
+ * instead of serialized ProseMirror markup strings.
  */
 export function toMarkup(text, format = 'markdown') {
   if (!text) return new MarkupContent('');

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -105,6 +105,64 @@ describe('Unit Tests', () => {
     });
   });
 
+  // ── Comment markup serialization ────────────────────────────
+
+  describe('Comment markup serialization', () => {
+    let HulyClient, fromCollaboratorMarkup;
+
+    before(async () => {
+      const clientMod = await import('../src/client.mjs');
+      const helpersMod = await import('../src/helpers.mjs');
+      HulyClient = clientMod.HulyClient;
+      fromCollaboratorMarkup = helpersMod.fromCollaboratorMarkup;
+    });
+
+    function createHarness(fakeSdk) {
+      const client = new HulyClient({
+        url: HULY_URL,
+        token: 'test-token',
+        workspace: 'test-workspace'
+      });
+      client._getClient = async () => fakeSdk;
+      client._parseAndFindIssue = async () => ({
+        project: { _id: 'project-space' },
+        issue: { _id: 'issue-id' }
+      });
+      return client;
+    }
+
+    it('serializes added comments as ProseMirror markup strings', async () => {
+      let payload;
+      const fakeSdk = {
+        addCollection: async (_classRef, _space, _attachedTo, _attachedToClass, _collection, data) => {
+          payload = data;
+        }
+      };
+
+      const client = createHarness(fakeSdk);
+      await client.addComment('TEST-1', '**Hello** comment', 'markdown');
+
+      assert.equal(typeof payload.message, 'string');
+      assert.equal(fromCollaboratorMarkup(payload.message), '**Hello** comment');
+    });
+
+    it('serializes updated comments as ProseMirror markup strings', async () => {
+      let updates;
+      const fakeSdk = {
+        findOne: async () => ({ _id: 'comment-id' }),
+        updateDoc: async (_classRef, _space, _id, data) => {
+          updates = data;
+        }
+      };
+
+      const client = createHarness(fakeSdk);
+      await client.updateComment('TEST-1', 'comment-id', 'Updated comment', 'plain');
+
+      assert.equal(typeof updates.message, 'string');
+      assert.equal(fromCollaboratorMarkup(updates.message), 'Updated comment');
+    });
+  });
+
   // ── Issue ID regex parsing ──────────────────────────────────
 
   describe('Issue ID regex parsing', () => {


### PR DESCRIPTION
## Summary
- Store ChatMessage.message as serialized ProseMirror markup strings for add_comment and update_comment.
- Reuse the existing toCollaboratorMarkup conversion path instead of adding duplicate markup helper logic.
- Add unit regression coverage for added and updated comments to verify the stored payload is a string and round-trips through collaborator markup parsing.

This implements the valid bug reported in #20 and the behavior proposed in #21 while keeping the existing markup conversion surface small.

Closes #20

## Verification
- node --check src/client.mjs
- node --check src/helpers.mjs
- node --test --test-name-pattern="Unit Tests" test/integration.test.mjs
- node --test --test-name-pattern="Mock Tests" test/integration.test.mjs
- npm run lint
- HULY_WORKSPACE=<workspace> HULY_TEST_PROJECT=<project> npm test