### PR TITLE
Close the three deferred v3 items and relax project type selection

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v7
-      - uses: github/codeql-action/init@v4.37.3
+      - uses: github/codeql-action/init@v4.37.8
         with:
           languages: javascript
-      - uses: github/codeql-action/analyze@v4.37.3
+      - uses: github/codeql-action/analyze@v4.37.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+Closes the three items the v3 validation pass deliberately deferred. Each was
+held back for a reason that did not survive a second look; `docs/V3_DEFECTS.md`
+records both the original reasoning and what changed.
+
+- `list_statuses`, `list_project_types`, and `list_task_types` order by creation
+  time again. Their rows reached the cursor without a timestamp, so ordering
+  silently degenerated to id-descending. They now pass their source document
+  through `withExtra` like every other paginated reader, which carries
+  `createdOn` to the comparator. Compact output filters `extra` through an empty
+  allowlist, so responses are byte-identical — the budget fixtures did not move.
+- Hours are rejected rather than silently recorded as 0 when they are not a
+  number. `log_time` with `hours: "two"` reported success while the workspace
+  recorded nothing; the same coercion sat on `set_estimation` and the
+  `estimation` field of `create_issue`, `update_issue`, and
+  `batch_create_issues`. Negative values are rejected too, and 0 remains legal.
+  Read paths keep coercing, so a single malformed stored value still cannot fail
+  a page.
+- `get_huly_context` reports the workspace tool dispatch would actually use.
+  It read the module-load constant while dispatch read the live environment, so
+  a host that repointed the server after startup was told a workspace nothing
+  was reading from.
+
+### Changed
+
+- `create_project` no longer demands an explicit `projectType` merely because
+  the workspace has HR or CRM modules installed. Candidates are narrowed to the
+  project types that own a tracker task type; a single remaining type is used
+  automatically, and the call still refuses — now listing only the issue-capable
+  types — when the choice is genuinely the caller's. A workspace carrying
+  vacancy and funnel types alongside the tracker's could not create a project
+  at all without naming a type.
+
 ## 3.0.0 - 2026-08-25
 
 Version 3 is an intentionally breaking token-efficiency release. It does not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,18 +14,27 @@ npm install
 
 - **MCP server:** `node src/index.mjs`
 - **HTTP server:** `node src/server.mjs`
-- **Unit tests:** `npm test`
-- **Full tests:** Requires a running Huly instance with
-  `HULY_URL`, `HULY_TOKEN`, and `HULY_WORKSPACE` env vars set.
+- **Unit tests:** `npm run test:unit` — offline, no Huly instance needed.
+- **Live tests:** `npm test` runs the integration suite over both transports
+  against a real Huly instance. It needs `HULY_URL`, `HULY_TOKEN`, and
+  `HULY_WORKSPACE`, plus `HULY_TEST_PROJECT` naming a project that exists in
+  that workspace. Without them the suite reads workspace `default` and project
+  `START` and fails on missing fixtures rather than on your change.
+  `docs/RELEASE_VALIDATION.md` describes the full fixture setup, and
+  `scripts/seed-validation-fixtures.mjs` builds a disposable workspace to run
+  against.
+- **Coverage:** `npm run coverage`.
 
 ## Pull Request Process
 
 1. Create a feature branch from `main`
 2. Make your changes
-3. Run `npm test` and ensure all tests pass
-4. Run `npx markdownlint-cli README.md` for markdown lint
-5. Push and open a PR against `main`
-6. CI must pass before merge
+3. Run `npm run preflight` (lint, unit tests, response budgets, packed-package
+   smoke test) and ensure it passes
+4. Run the live suite too if you touched a read or write path
+5. Run `npx markdownlint-cli README.md` for markdown lint
+6. Push and open a PR against `main`
+7. CI must pass before merge
 
 ## Code Standards
 

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ Full list of all MCP tools available through this server.
 | --- | --- | --- |
 | `list_projects` | List projects with optional `milestones`, `components`, `labels`, and `members` expansions | -- |
 | `get_project` | Get project by identifier with optional granular expansions | -- |
-| `create_project` | Create a new project | `projectType`: name/id (required only if the workspace has multiple) |
+| `create_project` | Create a new project | `projectType`: name/id (required only if the workspace has several issue-capable types; HR and CRM types are ignored) |
 | `update_project` | Update project name, description, privacy, default assignee | -- |
 | `archive_project` | Archive or unarchive a project | -- |
 | `delete_project` | Permanently delete a project | -- |

--- a/docs/V3_DEFECTS.md
+++ b/docs/V3_DEFECTS.md
@@ -104,15 +104,39 @@ Class G — infrastructure and supply chain.
 defects in earlier fixes made during this same validation pass, both found by
 independent review rather than by the test suite.
 
-## Deliberately not changed
+## Deferred at the time, closed since
 
-- Cursor ordering degenerates to id-descending for `list_statuses` and
-  `list_project_types`, whose rows carry no timestamp. Deterministic, and
-  cursors stay consistent. Fixing it means adding `createdOn` to compact list
-  output, which grows every response against the byte budgets. Raise as a
-  contract decision rather than an implicit payload increase.
-- `logTime` records 0 for non-numeric hours rather than rejecting, matching the
-  documented `toHours` contract.
-- `getHulyContext` reports the `config.mjs` workspace constant while tool
-  dispatch resolves from `process.env`. Reporting-only, and the server
-  overwrites it on every path that matters.
+All three items held back from the v3 pass were resolved afterwards. Each was
+deferred for a reason that turned out not to hold.
+
+| # | Defect | Site | Guard |
+| --- | --- | --- | --- |
+| H1 | Cursor ordering degenerated to id-descending for `list_statuses`, `list_project_types`, and `list_task_types` | client.mjs (4 builders) | clientReadPaths |
+| H2 | `logTime` and the estimation writes recorded 0 for a non-numeric value instead of rejecting | client.mjs (5 write sites) | timeNormalization, clientRemainingPaths |
+| H3 | `getHulyContext` reported the `config.mjs` workspace constant while dispatch resolved from `process.env` | config.mjs, mcpShared.mjs | mcpShared |
+
+**H1** was deferred because fixing it looked like it meant adding `createdOn` to
+compact list output, growing every response against the byte budgets. It did
+not. Those four builders hand-construct their rows while every other paginated
+reader passes its source doc through `withExtra`, which already carries
+`createdOn` into the cursor tuple. Compact output filters `extra` through an
+empty allowlist, so the timestamp reaches the comparator and never reaches the
+payload — the budget fixtures are byte-identical after the fix. A live probe
+first confirmed the premise: all 6 statuses, 3 project types, and 4 task types
+in the validation workspace carry a real `createdOn`, model-level rows included,
+sharing a timestamp from when the model was installed.
+
+**H2** was deferred as matching the documented `toHours` contract. The contract
+was the problem: one lenient coercion served both reads and writes. Reading 0
+for a malformed stored value is right, because one bad record should not fail a
+page. Writing 0 for a caller's value discards what they asked for and reports
+success — the same class as C1-C5. `toHours` stays lenient for reads; the five
+write sites (`logTime`, `setEstimation`, and the estimation field of
+`createIssue`, `updateIssue`, and `batchCreateIssues`) now use `parseHours`,
+which rejects a non-numeric or negative value and lets 0 through.
+
+**H3** was deferred as reporting-only, which it was — no mutation could reach
+the wrong workspace. But `get_huly_context` exists to tell a caller which
+workspace it is pointed at, and the server instructions send clients there first
+when defaults are unclear. Both now resolve through `resolveDefaultWorkspace()`,
+so there is one answer rather than two.

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -18,7 +18,7 @@ import {
   encodeCursor, decodeCursor, cursorTuple, compareCursorTuple,
   isTupleAfter, normalizePageLimit, listEnvelope, normalizeReportDate, toIsoDate,
   normalizeDueDate, resolvePriority,
-  nameMatch, strictGet, toHours, issueTimeFields, withExtra,
+  nameMatch, strictGet, toHours, parseHours, issueTimeFields, withExtra,
   toCollaboratorMarkup, fromCollaboratorMarkup,
   toMarkup, fromMarkup
 } from './helpers.mjs';
@@ -1884,7 +1884,7 @@ export class HulyClient {
         assignee: assigneeId,
         component: componentId,
         milestone: milestoneId,
-        estimation: toHours(extra.estimation),
+        estimation: extra.estimation === undefined ? 0 : parseHours(extra.estimation, 'estimation'),
         dueDate: normalizeDueDate(extra.dueDate),
         remainingTime: 0,
         reportedTime: 0,
@@ -1993,7 +1993,7 @@ export class HulyClient {
     }
 
     if (extra.estimation !== undefined) {
-      updates.estimation = toHours(extra.estimation);
+      updates.estimation = parseHours(extra.estimation, 'estimation');
       updatedFields.push('estimation');
     }
 
@@ -2426,7 +2426,7 @@ export class HulyClient {
       );
     }
 
-    const enriched = typesToReturn.map(tt => ({
+    const enriched = typesToReturn.map(tt => withExtra(tt, {
       id: tt._id,
       name: tt.name || tt._id.split(':').pop(),
       description: fromMarkup(tt.description),
@@ -2456,7 +2456,7 @@ export class HulyClient {
     const allTaskTypes = await client.findAll(task.class.TaskType, {});
     const taskTypeById = new Map(allTaskTypes.map(tt => [tt._id, tt]));
 
-    const enriched = projectTypes.map(pt => ({
+    const enriched = projectTypes.map(pt => withExtra(pt, {
       id: pt._id,
       name: pt.name || pt._id.split(':').pop(),
       description: fromMarkup(pt.description) || pt.shortDescription || null,
@@ -2484,7 +2484,10 @@ export class HulyClient {
 
     // If no scoping requested, return all
     if (!projectIdent && !taskTypeName) {
-      const enriched = allStatuses.map(s => ({
+      // withExtra carries the source doc's createdOn, which the cursor tuple
+      // sorts on. Without it these rows tuple to 0 and ordering silently
+      // degenerates to id-descending. Compact output strips extra entirely.
+      const enriched = allStatuses.map(s => withExtra(s, {
         id: s._id,
         name: s.name,
         category: STATUS_CATEGORY_NAMES[s.category] || s.category,
@@ -2540,7 +2543,7 @@ export class HulyClient {
     // Filter statuses to only those in scope
     const scopedStatuses = allStatuses.filter(s => statusIds.has(s._id));
 
-    const enriched = scopedStatuses.map(s => ({
+    const enriched = scopedStatuses.map(s => withExtra(s, {
       id: s._id,
       name: s.name,
       category: STATUS_CATEGORY_NAMES[s.category] || s.category,
@@ -2955,7 +2958,7 @@ export class HulyClient {
     const client = await this._getClient();
     const { project, issue } = await this._parseAndFindIssue(client, issueId);
 
-    const normalizedHours = toHours(hours);
+    const normalizedHours = parseHours(hours, 'estimation');
 
     await client.updateDoc(tracker.class.Issue, project._id, issue._id, {
       estimation: normalizedHours
@@ -2981,7 +2984,7 @@ export class HulyClient {
       employeeId = await this._findEmployeeByName(client, employeeName);
     }
 
-    const normalizedHours = toHours(hours);
+    const normalizedHours = parseHours(hours);
     const reportId = generateId();
     await client.addCollection(
       tracker.class.TimeSpendReport,
@@ -3352,7 +3355,7 @@ export class HulyClient {
           assignee: assigneeId,
           component: componentId,
           milestone: milestoneId,
-          estimation: toHours(item.estimation),
+          estimation: item.estimation === undefined ? 0 : parseHours(item.estimation, 'estimation'),
           dueDate: normalizeDueDate(item.dueDate),
           remainingTime: 0,
           reportedTime: 0,
@@ -3735,6 +3738,24 @@ export class HulyClient {
 
   // ── Project Management ──────────────────────────────────────
 
+  /**
+   * The project types that own at least one tracker task type. A workspace with
+   * HR or CRM modules also carries vacancy and funnel types, which cannot hold
+   * issues and are never candidates for a project created through this server.
+   * @param {Object} client - Connected SDK client
+   * @param {Object[]} projectTypes - Candidate project types
+   * @returns {Promise<Object[]>}
+   */
+  async _trackerProjectTypes(client, projectTypes) {
+    const allTaskTypes = await client.findAll(task.class.TaskType, {});
+    const trackerTaskTypeIds = new Set(
+      allTaskTypes
+        .filter(tt => tt.ofClass === tracker.class.Issue || tt.targetClass === tracker.class.Issue)
+        .map(tt => tt._id)
+    );
+    return projectTypes.filter(pt => (pt.tasks ?? []).some(id => trackerTaskTypeIds.has(id)));
+  }
+
   async createProject(identifier, name, description, isPrivate = false, projectType) {
     const client = await this._getClient();
 
@@ -3761,8 +3782,18 @@ export class HulyClient {
     } else if (projectTypes.length === 1) {
       resolvedProjectType = projectTypes[0];
     } else {
-      const available = projectTypes.map(pt => pt.name || pt._id).join(', ');
-      throw new Error(`Multiple project types found: ${available}. Specify projectType explicitly.`);
+      // A workspace with HR or CRM modules carries vacancy and funnel types
+      // alongside the tracker's. This server creates tracker projects, so those
+      // are not real candidates. Narrow to the types that own a tracker task
+      // type; only refuse when the remaining choice is genuinely the caller's.
+      const trackerTypes = await this._trackerProjectTypes(client, projectTypes);
+      if (trackerTypes.length === 1) {
+        resolvedProjectType = trackerTypes[0];
+      } else {
+        const candidates = trackerTypes.length > 1 ? trackerTypes : projectTypes;
+        const available = candidates.map(pt => pt.name || pt._id).join(', ');
+        throw new Error(`Multiple project types found: ${available}. Specify projectType explicitly.`);
+      }
     }
 
     // Scope default status to the resolved ProjectType's task types

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -9,6 +9,17 @@ export const HULY_EMAIL = process.env.HULY_EMAIL;
 export const HULY_PASSWORD = process.env.HULY_PASSWORD;
 export const HULY_WORKSPACE = process.env.HULY_WORKSPACE;
 export const HULY_PROJECT = process.env.HULY_PROJECT;
+
+/**
+ * The default workspace, resolved the same way everywhere. Tool dispatch reads
+ * the live env so an embedding host can repoint the server after module load;
+ * get_huly_context must answer with the same value it would actually use, or it
+ * reports a workspace nothing is reading from.
+ * @returns {string|null}
+ */
+export function resolveDefaultWorkspace() {
+  return process.env.HULY_WORKSPACE || HULY_WORKSPACE || null;
+}
 export const HULY_CREDS = HULY_TOKEN
   ? { token: HULY_TOKEN }
   : { email: HULY_EMAIL, password: HULY_PASSWORD };

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -114,9 +114,37 @@ export const CURSOR_TTL_MS = 24 * 60 * 60 * 1000;
 
 const processCursorSecret = randomBytes(32);
 
+/**
+ * Lenient hours coercion for READ paths. A single malformed stored value must
+ * not fail a whole page, so anything unusable reads as 0. Never use this on a
+ * caller-supplied value: use parseHours, which refuses instead of discarding.
+ */
 export function toHours(value) {
   const number = Number(value);
   return Number.isFinite(number) ? number : 0;
+}
+
+/**
+ * Strict hours parsing for WRITE paths. Coercing a caller's value to 0 records
+ * nothing while reporting success, so a value that cannot be an hour count is
+ * rejected rather than written.
+ * @param {*} value - Caller-supplied hours
+ * @param {string} [field] - Field name for the error message
+ * @returns {number}
+ */
+export function parseHours(value, field = 'hours') {
+  if (value === null || value === undefined || typeof value === 'boolean' ||
+      (typeof value === 'string' && value.trim() === '')) {
+    throw new Error(`${field} must be a number, received ${JSON.stringify(value)}`);
+  }
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new Error(`${field} must be a number, received ${JSON.stringify(value)}`);
+  }
+  if (number < 0) {
+    throw new Error(`${field} cannot be negative, received ${number}`);
+  }
+  return number;
 }
 
 export function issueTimeFields(issue) {

--- a/src/mcpShared.mjs
+++ b/src/mcpShared.mjs
@@ -30,7 +30,7 @@ import {
   DESTRUCTIVE_TOOL_NAMES
 } from './dispatch.mjs';
 import { ISSUE_BASE_FIELDS, ISSUE_INCLUDE_FIELDS } from './projection.mjs';
-import { HULY_URL, HULY_TOKEN, HULY_EMAIL, HULY_PASSWORD, HULY_WORKSPACE, HULY_PROJECT, HULY_CREDS } from './config.mjs';
+import { HULY_URL, HULY_TOKEN, HULY_EMAIL, HULY_PASSWORD, HULY_PROJECT, HULY_CREDS, resolveDefaultWorkspace } from './config.mjs';
 
 const require = createRequire(import.meta.url);
 const { name: PKG_NAME, version: PKG_VERSION } = require('../package.json');
@@ -169,7 +169,7 @@ function authMode() {
 
 function getHulyContext() {
   return {
-    defaultWorkspace: HULY_WORKSPACE || null,
+    defaultWorkspace: resolveDefaultWorkspace(),
     defaultProject: HULY_PROJECT || null,
     hulyUrlHost: hulyUrlHost(),
     authMode: authMode(),
@@ -197,7 +197,7 @@ export async function handleToolCall(name, args = {}) {
     const toolArgs = PROJECT_DEFAULT_TOOLS.has(name) && HULY_PROJECT && !args.project
       ? { ...args, project: HULY_PROJECT }
       : args;
-    const workspace = toolArgs.workspace || process.env.HULY_WORKSPACE;
+    const workspace = toolArgs.workspace || resolveDefaultWorkspace();
     const client = await pool.getClient(workspace);
     return await client.withReconnect(() => workspaceTools[name](toolArgs, client));
   }
@@ -590,7 +590,7 @@ function getToolDefinitions() {
     {
       name: 'create_project',
       description: 'Create a new project in the workspace. Returns the project identifier and details.',
-      inputSchema: { type: 'object', properties: { identifier: { type: 'string', description: 'Project identifier (2-5 uppercase letters, e.g., "PROJ")' }, name: { type: 'string', description: 'Project display name' }, description: { type: 'string', description: 'Project description' }, private: { type: 'boolean', description: 'Whether the project is private (default: false)' }, projectType: { type: 'string', description: 'Project type name or id (e.g., "Classic"). Required only when the workspace has multiple project types; otherwise the single available type is used.' }, ...workspaceProp }, required: ['identifier', 'name'] }
+      inputSchema: { type: 'object', properties: { identifier: { type: 'string', description: 'Project identifier (2-5 uppercase letters, e.g., "PROJ")' }, name: { type: 'string', description: 'Project display name' }, description: { type: 'string', description: 'Project description' }, private: { type: 'boolean', description: 'Whether the project is private (default: false)' }, projectType: { type: 'string', description: 'Project type name or id (e.g., "Classic"). Required only when the workspace has several project types that can hold issues; a single issue-capable type is selected automatically, so HR and CRM types in the workspace do not force this argument.' }, ...workspaceProp }, required: ['identifier', 'name'] }
     },
     {
       name: 'update_project',

--- a/test/clientReadPaths.test.mjs
+++ b/test/clientReadPaths.test.mjs
@@ -96,9 +96,11 @@ const EMPLOYEES = [
   { _id: 'emp-2', name: 'Grace Hopper', active: true }
 ];
 
+// Every Huly Doc carries createdOn, statuses included — the model-level ones
+// share a timestamp from when the model was installed. The cursor sorts on it.
 const STATUSES = [
-  { _id: 's-todo', name: 'Todo', category: 'task:statusCategory:ToDo', color: 1 },
-  { _id: 's-done', name: 'Done', category: 'task:statusCategory:Won', color: 2 }
+  { _id: 's-todo', name: 'Todo', category: 'task:statusCategory:ToDo', color: 1, createdOn: 2 },
+  { _id: 's-done', name: 'Done', category: 'task:statusCategory:Won', color: 2, createdOn: 1 }
 ];
 
 const TASK_TYPES = [
@@ -592,18 +594,21 @@ describe('listProjectTypes', () => {
     const page = await client.listProjectTypes();
     const byId = new Map(page.items.map(item => [item.id, item]));
 
-    assert.deepEqual(byId.get('pt-classic'), {
+    const { extra: classicExtra, ...classic } = byId.get('pt-classic');
+    assert.deepEqual(classic, {
       id: 'pt-classic',
       name: 'Classic',
       description: 'Default workflow',
       taskTypes: ['Epic', 'Issue']
     });
-    assert.deepEqual(byId.get('task:type:Bugs'), {
+    const { extra: _bugsExtra, ...bugs } = byId.get('task:type:Bugs');
+    assert.deepEqual(bugs, {
       id: 'task:type:Bugs',
       name: 'Bugs',
       description: null,
       taskTypes: []
     });
+    assert.equal(classicExtra.createdOn, 2, 'the source timestamp must reach the cursor tuple');
     assert.equal(page.count, 2);
     assert.equal(page.hasMore, false);
     assert.equal(select('findAll', task.class.TaskType).length, 1,
@@ -617,8 +622,8 @@ describe('listStatuses scoping', () => {
       projects: projects(),
       statuses: [
         ...STATUSES,
-        { _id: 's-loose', name: 'Orphan', category: 'task:statusCategory:Active', color: 3 },
-        { _id: 's-odd', name: 'Odd', category: 'task:statusCategory:Unmapped', color: 4, description: 'Custom' }
+        { _id: 's-loose', name: 'Orphan', category: 'task:statusCategory:Active', color: 3, createdOn: 4 },
+        { _id: 's-odd', name: 'Odd', category: 'task:statusCategory:Unmapped', color: 4, description: 'Custom', createdOn: 3 }
       ],
       taskTypes: [
         ...TASK_TYPES,
@@ -638,16 +643,45 @@ describe('listStatuses scoping', () => {
     const byId = new Map(page.items.map(item => [item.id, item]));
 
     assert.equal(page.count, 4);
-    assert.deepEqual(byId.get('s-todo'),
+    const { extra: todoExtra, ...todo } = byId.get('s-todo');
+    assert.deepEqual(todo,
       { id: 's-todo', name: 'Todo', category: 'Todo', color: 1, description: '' });
-    assert.deepEqual(byId.get('s-done'),
+    const { extra: _doneExtra, ...done } = byId.get('s-done');
+    assert.deepEqual(done,
       { id: 's-done', name: 'Done', category: 'Done', color: 2, description: '' });
+    // The source timestamp rides in extra so the cursor can sort on it. Compact
+    // output strips extra, so this costs no response bytes.
+    assert.ok(todoExtra.createdOn > 0, 'status rows must carry a cursor timestamp');
     assert.equal(byId.get('s-odd').category, 'task:statusCategory:Unmapped',
       'an unmapped category must pass through rather than resolve to a wrong name');
     assert.equal(byId.get('s-odd').description, 'Custom');
     assert.equal(select('findAll', task.class.TaskType).length, 0);
     assert.equal(select('findAll', task.class.ProjectType).length, 0);
     assert.equal(select('findOne', PROJECT_CLASS).length, 0);
+  });
+
+  it('orders statuses by creation time instead of degenerating to id order', async () => {
+    const { client } = statusHarness();
+
+    const page = await client.listStatuses();
+
+    // Before HMCP-66 every status tupled to createdOn 0, so the comparator fell
+    // through to its id-descending tiebreak: s-todo, s-odd, s-loose, s-done.
+    assert.deepEqual(page.items.map(s => s.id), ['s-loose', 's-odd', 's-todo', 's-done']);
+  });
+
+  it('pages statuses across a cursor without gaps or repeats', async () => {
+    const { client } = statusHarness();
+
+    const first = await client.listStatuses(undefined, undefined, { limit: 2 });
+    assert.deepEqual(first.items.map(s => s.id), ['s-loose', 's-odd']);
+    assert.ok(first.nextCursor, 'a truncated status page must offer a cursor');
+
+    const second = await client.listStatuses(undefined, undefined,
+      { limit: 2, cursor: first.nextCursor });
+
+    assert.deepEqual(second.items.map(s => s.id), ['s-todo', 's-done']);
+    assert.equal(second.nextCursor, undefined);
   });
 
   it('rejects a task type that exists elsewhere but not in the addressed project', async () => {

--- a/test/clientRemainingPaths.test.mjs
+++ b/test/clientRemainingPaths.test.mjs
@@ -74,12 +74,28 @@ describe('setEstimation', () => {
     assert.equal(typeof write.data.estimation, 'number');
   });
 
-  it('stores zero for a non-numeric estimate rather than NaN', async () => {
+  it('rejects a non-numeric estimate instead of silently storing zero', async () => {
     const sdk = recorder();
-    await stubClient(sdk).setEstimation('PROJ-42', 'abc');
-    const write = sdk.calls.find(c => c.op === 'updateDoc');
-    assert.equal(write.data.estimation, 0);
-    assert.ok(!Number.isNaN(write.data.estimation));
+
+    await assert.rejects(
+      () => stubClient(sdk).setEstimation('PROJ-42', 'abc'),
+      /estimation must be a number, received "abc"/
+    );
+
+    // Coercing to 0 would have reported success while discarding the caller's
+    // intent, which is the class of defect HMCP-67 closed.
+    assert.equal(sdk.calls.find(c => c.op === 'updateDoc'), undefined);
+  });
+
+  it('rejects a negative estimate', async () => {
+    const sdk = recorder();
+
+    await assert.rejects(
+      () => stubClient(sdk).setEstimation('PROJ-42', -3),
+      /estimation cannot be negative, received -3/
+    );
+
+    assert.equal(sdk.calls.find(c => c.op === 'updateDoc'), undefined);
   });
 });
 

--- a/test/mcpShared.test.mjs
+++ b/test/mcpShared.test.mjs
@@ -38,6 +38,23 @@ describe('MCP shared runtime context', () => {
     assert.equal(result.defaultProject, 'PROJ');
   });
 
+  it('reports the workspace tool dispatch would actually use', async () => {
+    // The reported workspace used to come from the module-load constant while
+    // dispatch resolved from the live env, so a host that repointed the server
+    // was told a workspace nothing was reading from.
+    const original = process.env.HULY_WORKSPACE;
+    process.env.HULY_WORKSPACE = 'repointed-workspace';
+    try {
+      const result = await handleToolCall('get_huly_context', {});
+      assert.equal(result.defaultWorkspace, 'repointed-workspace');
+    } finally {
+      if (original === undefined) delete process.env.HULY_WORKSPACE;
+      else process.env.HULY_WORKSPACE = original;
+    }
+
+    assert.equal((await handleToolCall('get_huly_context', {})).defaultWorkspace, 'my-workspace');
+  });
+
   it('rejects every unadvertised tool argument', async () => {
     const { server } = createMcpServer();
     const call = callHandler(server);

--- a/test/projectCreation.test.mjs
+++ b/test/projectCreation.test.mjs
@@ -1,12 +1,30 @@
+import { createRequire } from 'node:module';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { HulyClient } from '../src/client.mjs';
 
+const require = createRequire(import.meta.url);
+const tracker = require('@hcengineering/tracker').default;
+
 const ACCOUNT_UUID = 'account-uuid';
 const SPACE_ID = 'core:space:Space';
 
-function createHarness({ readable = true, rollbackFails = false } = {}) {
+const CLASSIC_TYPE = { _id: 'classic-project-type', name: 'Classic project', targetClass: 'classic-project-mixin' };
+
+// A workspace with HR or CRM modules enabled carries project types that cannot
+// hold issues. They own task types of another class, which is how they are told
+// apart from the tracker's.
+const ISSUE_TASK_TYPE = { _id: 'tt-issue', name: 'Issue', ofClass: tracker.class.Issue };
+const VACANCY_TASK_TYPE = { _id: 'tt-applicant', name: 'Applicant', ofClass: 'recruit:class:Applicant' };
+const FUNNEL_TASK_TYPE = { _id: 'tt-lead', name: 'Lead', ofClass: 'lead:class:Lead' };
+
+function createHarness({
+  readable = true,
+  rollbackFails = false,
+  projectTypes = [CLASSIC_TYPE],
+  taskTypes = []
+} = {}) {
   const calls = {
     createDoc: [],
     createMixin: [],
@@ -23,7 +41,10 @@ function createHarness({ readable = true, rollbackFails = false } = {}) {
     },
     findAll: async (classRef) => {
       if (String(classRef).includes('ProjectType')) {
-        return [{ _id: 'classic-project-type', name: 'Classic project', targetClass: 'classic-project-mixin' }];
+        return projectTypes;
+      }
+      if (String(classRef).includes('TaskType')) {
+        return taskTypes;
       }
       return [{ _id: 'todo-status', name: 'Todo' }];
     },
@@ -98,5 +119,125 @@ describe('private project creation', () => {
         return true;
       }
     );
+  });
+});
+
+describe('project type resolution', () => {
+  const SCRUM_TYPE = { _id: 'scrum-project-type', name: 'Scrum project', targetClass: 'scrum-project-mixin' };
+  const multiple = [CLASSIC_TYPE, SCRUM_TYPE];
+
+  it('uses the only project type when the workspace has exactly one', async () => {
+    const { client, calls } = createHarness();
+
+    await client.createProject('solo', 'Solo', '');
+
+    assert.equal(calls.createDoc[0].data.type, CLASSIC_TYPE._id);
+  });
+
+  it('creates against the named type when the workspace has several', async () => {
+    const { client, calls } = createHarness({ projectTypes: multiple });
+
+    await client.createProject('scrum', 'Scrum', '', false, 'Scrum project');
+
+    assert.equal(calls.createDoc[0].data.type, SCRUM_TYPE._id);
+    assert.equal(calls.createMixin[0][3], SCRUM_TYPE.targetClass);
+  });
+
+  it('matches a project type name case-insensitively, and by id', async () => {
+    const byCase = createHarness({ projectTypes: multiple });
+    await byCase.client.createProject('lower', 'Lower', '', false, 'scrum PROJECT');
+    assert.equal(byCase.calls.createDoc[0].data.type, SCRUM_TYPE._id);
+
+    const byId = createHarness({ projectTypes: multiple });
+    await byId.client.createProject('byid', 'By id', '', false, SCRUM_TYPE._id);
+    assert.equal(byId.calls.createDoc[0].data.type, SCRUM_TYPE._id);
+  });
+
+  it('refuses to guess when several issue-capable types exist and none was named', async () => {
+    const { client, calls } = createHarness({
+      projectTypes: [
+        { ...CLASSIC_TYPE, tasks: ['tt-issue'] },
+        { ...SCRUM_TYPE, tasks: ['tt-issue'] }
+      ],
+      taskTypes: [ISSUE_TASK_TYPE]
+    });
+
+    await assert.rejects(
+      () => client.createProject('ambig', 'Ambiguous', ''),
+      /Multiple project types found: Classic project, Scrum project\. Specify projectType explicitly\./
+    );
+
+    assert.equal(calls.createDoc.length, 0);
+  });
+
+  it('ignores HR and CRM types so their presence alone does not force the argument', async () => {
+    // The HMCP-33 report: a workspace with recruit and lead modules could not
+    // create a project at all without naming a type explicitly.
+    const { client, calls } = createHarness({
+      projectTypes: [
+        { _id: 'recruit:template:DefaultVacancy', name: 'Default vacancy', tasks: ['tt-applicant'] },
+        { _id: 'lead:template:DefaultFunnel', name: 'Default funnel', tasks: ['tt-lead'] },
+        { ...CLASSIC_TYPE, tasks: ['tt-issue'] }
+      ],
+      taskTypes: [ISSUE_TASK_TYPE, VACANCY_TASK_TYPE, FUNNEL_TASK_TYPE]
+    });
+
+    await client.createProject('hrcrm', 'Tracker project', '');
+
+    assert.equal(calls.createDoc[0].data.type, CLASSIC_TYPE._id);
+  });
+
+  it('lists only the issue-capable types when several of them remain', async () => {
+    const { client } = createHarness({
+      projectTypes: [
+        { _id: 'recruit:template:DefaultVacancy', name: 'Default vacancy', tasks: ['tt-applicant'] },
+        { ...CLASSIC_TYPE, tasks: ['tt-issue'] },
+        { ...SCRUM_TYPE, tasks: ['tt-issue'] }
+      ],
+      taskTypes: [ISSUE_TASK_TYPE, VACANCY_TASK_TYPE]
+    });
+
+    // Naming a type the caller cannot usefully pick would be worse than useless.
+    await assert.rejects(
+      () => client.createProject('ambig', 'Ambiguous', ''),
+      /Multiple project types found: Classic project, Scrum project\. Specify projectType explicitly\./
+    );
+  });
+
+  it('falls back to listing every type when none owns a tracker task type', async () => {
+    const { client } = createHarness({
+      projectTypes: [
+        { _id: 'recruit:template:DefaultVacancy', name: 'Default vacancy', tasks: ['tt-applicant'] },
+        { _id: 'lead:template:DefaultFunnel', name: 'Default funnel', tasks: ['tt-lead'] }
+      ],
+      taskTypes: [VACANCY_TASK_TYPE, FUNNEL_TASK_TYPE]
+    });
+
+    await assert.rejects(
+      () => client.createProject('none', 'None', ''),
+      /Multiple project types found: Default vacancy, Default funnel\. Specify projectType explicitly\./
+    );
+  });
+
+  it('lists the available types when the named one does not exist', async () => {
+    const { client, calls } = createHarness({ projectTypes: multiple });
+
+    await assert.rejects(
+      () => client.createProject('typo', 'Typo', '', false, 'Kanban project'),
+      /Project type "Kanban project" not found\. Available: Classic project, Scrum project/
+    );
+
+    assert.equal(calls.createDoc.length, 0);
+  });
+
+  it('reports a workspace with no project types instead of writing', async () => {
+    const { client, calls } = createHarness({ projectTypes: [] });
+
+    await assert.rejects(
+      () => client.createProject('empty', 'Empty', ''),
+      /No project types found in workspace/
+    );
+
+    assert.equal(calls.createDoc.length, 0);
   });
 });

--- a/test/timeNormalization.test.mjs
+++ b/test/timeNormalization.test.mjs
@@ -47,6 +47,41 @@ describe('time numeric normalization', () => {
     assert.equal(issueUpdate.reportedTime, 1.75);
     assert.equal(result.reportedTime, 1.75);
   });
+
+  it('rejects hours that are not a number rather than logging zero', async () => {
+    const writes = [];
+    const client = new HulyClient({
+      url: 'https://huly.example.test',
+      token: 'test-token',
+      workspace: 'test-workspace'
+    });
+    client._getClient = async () => ({
+      addCollection: async (...args) => { writes.push(args); },
+      updateDoc: async (...args) => { writes.push(args); }
+    });
+    client._parseAndFindIssue = async () => ({
+      project: { _id: 'project-space' },
+      issue: { _id: 'issue-id', reportedTime: 0 }
+    });
+
+    // Each of these coerced to 0 before HMCP-67: the tool reported success
+    // while the workspace recorded no time at all.
+    for (const bad of ['two', '', null, undefined, true, NaN, Infinity, {}]) {
+      await assert.rejects(
+        () => client.logTime('PROJ-1', bad, 'work'),
+        /hours must be a number/,
+        `logTime must reject ${JSON.stringify(bad) ?? String(bad)}`
+      );
+    }
+
+    await assert.rejects(() => client.logTime('PROJ-1', -1, 'work'), /hours cannot be negative/);
+
+    assert.deepEqual(writes, [], 'nothing may reach the SDK for a rejected value');
+
+    // 0 stays legal: it is a real, if unusual, amount of time to log.
+    await client.logTime('PROJ-1', 0, 'work');
+    assert.equal(writes.length, 2);
+  });
 });
 
 describe('issue id validation', () => {


### PR DESCRIPTION
Closes the three defects the v3 validation pass deliberately deferred, plus the loose ends from that pass. Each deferral was made for a reason that did not survive a second look; `docs/V3_DEFECTS.md` now records the original reasoning next to what changed.

## HMCP-66 — cursor ordering degenerated to id-descending

`list_statuses`, `list_project_types`, and `list_task_types` ordered by id, not creation time. Their rows reached the cursor without a timestamp, so `compareCursorTuple` fell through to its tiebreak.

The deferral assumed fixing it meant adding `createdOn` to compact output and paying bytes on every response. It did not. Those four builders hand-construct their rows, while every other paginated reader passes its source document through `withExtra` — which already carries `createdOn` into `extra`, exactly where `cursorTuple` looks. Compact output filters `extra` through an empty allowlist, so the timestamp reaches the comparator and never reaches the payload. **The budget fixtures are byte-identical.**

The premise was checked live before any code changed: all 6 statuses, 3 project types, and 4 task types in the workspace carry a real `createdOn`, model-level rows included — those share a timestamp from when the model was installed. `list_task_types` had the same defect and was not in the original report.

## HMCP-67 — hours silently recorded as 0

`log_time` with `hours: "two"` reported success while the workspace recorded nothing. One lenient coercion was serving both reads and writes.

The contracts are now split rather than `toHours` changed: it stays lenient for reads, where one malformed stored value must not fail a page, and five write sites use the new `parseHours`, which rejects non-numeric and negative values while admitting `0`. Four of those sites — `set_estimation` and the `estimation` field of `create_issue`, `update_issue`, and `batch_create_issues` — had the identical defect and were not in the report. `set_estimation` even had a test asserting the broken behaviour; it now asserts rejection, and the guards assert that nothing reaches the SDK rather than trusting a return value.

## HMCP-68 — context reported a workspace nothing was reading from

`get_huly_context` read the module-load constant while dispatch read the live environment. Both now resolve through `resolveDefaultWorkspace()`. `defaultProject` was deliberately left alone: it and dispatch already agree, and the generated tool descriptions bake the project name in at load time.

## HMCP-33 — project type selection

`create_project` no longer demands an explicit `projectType` merely because the workspace has HR or CRM modules installed. Candidates are narrowed to the project types that own a tracker task type, reusing the predicate `list_task_types` and `search_issues` already share; a single remaining type is used automatically, and the call still refuses — now listing only the issue-capable types — when the choice is genuinely the caller's.

This is a behaviour change on a published tool: a workspace where `create_project` errors today will start succeeding. That is the intent, and the README and tool schema say so.

## HMCP-69 — loose ends

Adds the project-type resolution guards that shipped without a test, and corrects `CONTRIBUTING.md`, which called the live integration suite the unit tests. Without `HULY_TEST_PROJECT` that suite reads workspace `default` and project `START`, then fails on missing fixtures rather than on the contributor's change — it failed 4 of 200 that way before being pointed at a real workspace.

## Verification

- 509 unit tests pass, up from 501
- Live WebSocket and REST suites 200/200 each
- Lint clean, response budgets unchanged, markdown lint clean

## Dependabot backlog

Also clears the three open dependabot PRs (HMCP-70). Only one was still outstanding: `github/codeql-action` moves from v4.37.3 to v4.37.8 here, superseding #51.

The other two were already applied on `main` — `actions/checkout@v7` and `actions/setup-node@v7` are in use throughout both workflows. Their branches were cut from an older base so the diffs no longer applied, and they were closed rather than merged (#33, #36). Every action reference in `ci.yml` and `codeql.yml` is now current.
