### PR TITLE
Report rolled-up child time on issue reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Rolled-up child time
+
+- `get_issue` and `list_issues` return `estimationTotal` and
+  `reportedTimeTotal` for an issue that has children. An issue's `estimation`
+  and `reportedTime` count only what is booked directly on it — Huly never rolls
+  descendants into those fields — so a parent previously read as empty while the
+  Huly UI showed a total. The totals are summed from the server-maintained
+  `childInfo` array, one level deep, matching what the UI displays.
+- Both fields are projectable through `fields`. An issue with no children emits
+  neither, so response sizes are unchanged for every leaf. `estimation` and
+  `reportedTime` keep their existing meaning, so existing parsers are
+  unaffected.
+
 ## 3.0.1 - 2026-08-31
 
 The v3 validation pass deferred three defects, each for a reason that did not

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -18,7 +18,7 @@ import {
   encodeCursor, decodeCursor, cursorTuple, compareCursorTuple,
   isTupleAfter, normalizePageLimit, listEnvelope, normalizeReportDate, toIsoDate,
   normalizeDueDate, resolvePriority,
-  nameMatch, strictGet, toHours, parseHours, issueTimeFields, withExtra,
+  nameMatch, strictGet, toHours, parseHours, issueTimeFields, issueRollupFields, withExtra,
   toCollaboratorMarkup, fromCollaboratorMarkup,
   toMarkup, fromMarkup
 } from './helpers.mjs';
@@ -1554,6 +1554,12 @@ export class HulyClient {
       const timeFields = this._issueTimeFields(issue);
       if (field('estimation')) entry.estimation = timeFields.estimation;
       if (field('reportedTime')) entry.reportedTime = timeFields.reportedTime;
+      // Only an issue with children carries a rollup, so a leaf costs no bytes.
+      const rollup = issueRollupFields(issue);
+      if (rollup) {
+        if (field('estimationTotal')) entry.estimationTotal = rollup.estimationTotal;
+        if (field('reportedTimeTotal')) entry.reportedTimeTotal = rollup.reportedTimeTotal;
+      }
       if (field('createdOn')) entry.createdOn = issue.createdOn;
       if (field('modifiedOn')) entry.modifiedOn = issue.modifiedOn;
       if (field('completedAt')) entry.completedAt = doneStatuses.has(issue.status) ? issue.modifiedOn : null;
@@ -1722,6 +1728,11 @@ export class HulyClient {
     const issueTimes = this._issueTimeFields(issue);
     if (field('estimation')) result.estimation = issueTimes.estimation;
     if (field('reportedTime')) result.reportedTime = issueTimes.reportedTime;
+    const issueRollup = issueRollupFields(issue);
+    if (issueRollup) {
+      if (field('estimationTotal')) result.estimationTotal = issueRollup.estimationTotal;
+      if (field('reportedTimeTotal')) result.reportedTimeTotal = issueRollup.reportedTimeTotal;
+    }
     if (field('createdOn')) result.createdOn = issue.createdOn;
     if (field('modifiedOn')) result.modifiedOn = issue.modifiedOn;
     if (field('completedAt')) result.completedAt = doneStatuses.has(issue.status) ? issue.modifiedOn : null;

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -154,6 +154,26 @@ export function issueTimeFields(issue) {
   };
 }
 
+/**
+ * Rolled-up time for an issue that has children, matching what the Huly UI
+ * displays. An issue's own `estimation` and `reportedTime` count only time
+ * booked directly on it; Huly never rolls descendants into those fields. The
+ * per-child totals live in the server-maintained `childInfo` array, and the UI
+ * sums one level — a grandchild's time reaches the grandparent only through
+ * its own parent's direct total, which is why this is deliberately not
+ * recursive.
+ * @param {Object} issue - Raw issue document carrying childInfo
+ * @returns {{estimationTotal: number, reportedTimeTotal: number}|null} null when the issue has no children
+ */
+export function issueRollupFields(issue) {
+  const children = issue?.childInfo;
+  if (!Array.isArray(children) || children.length === 0) return null;
+  return {
+    estimationTotal: children.reduce((sum, child) => sum + toHours(child?.estimation), toHours(issue?.estimation)),
+    reportedTimeTotal: children.reduce((sum, child) => sum + toHours(child?.reportedTime), toHours(issue?.reportedTime))
+  };
+}
+
 function stableValue(value) {
   if (Array.isArray(value)) return value.map(stableValue);
   if (!value || typeof value !== 'object') return value;

--- a/src/projection.mjs
+++ b/src/projection.mjs
@@ -1,7 +1,8 @@
 export const ISSUE_BASE_FIELDS = Object.freeze([
   'id', 'title', 'status', 'priority', 'type', 'assignee', 'component',
   'labels', 'parent', 'childCount', 'milestone', 'dueDate', 'estimation',
-  'reportedTime', 'createdOn', 'modifiedOn', 'completedAt'
+  'reportedTime', 'estimationTotal', 'reportedTimeTotal',
+  'createdOn', 'modifiedOn', 'completedAt'
 ]);
 
 export const ISSUE_INCLUDE_FIELDS = Object.freeze([

--- a/test/clientReadPaths.test.mjs
+++ b/test/clientReadPaths.test.mjs
@@ -665,8 +665,8 @@ describe('listStatuses scoping', () => {
 
     const page = await client.listStatuses();
 
-    // Before HMCP-66 every status tupled to createdOn 0, so the comparator fell
-    // through to its id-descending tiebreak: s-todo, s-odd, s-loose, s-done.
+    // When every status tuples to createdOn 0, the comparator falls through to
+    // its id-descending tiebreak and yields: s-todo, s-odd, s-loose, s-done.
     assert.deepEqual(page.items.map(s => s.id), ['s-loose', 's-odd', 's-todo', 's-done']);
   });
 

--- a/test/clientRemainingPaths.test.mjs
+++ b/test/clientRemainingPaths.test.mjs
@@ -82,8 +82,8 @@ describe('setEstimation', () => {
       /estimation must be a number, received "abc"/
     );
 
-    // Coercing to 0 would have reported success while discarding the caller's
-    // intent, which is the class of defect HMCP-67 closed.
+    // Coercing to 0 would report success while discarding the caller's intent,
+    // storing an estimate they never asked for.
     assert.equal(sdk.calls.find(c => c.op === 'updateDoc'), undefined);
   });
 

--- a/test/issueLifecycle.test.mjs
+++ b/test/issueLifecycle.test.mjs
@@ -635,6 +635,44 @@ describe('listIssues and getIssue projection', () => {
     }]);
   });
 
+  it('rolls child time up one level, as the Huly UI does', async () => {
+    // An issue's own reportedTime counts only time booked directly on it —
+    // Huly never rolls descendants into it. The per-child totals live in the
+    // server-maintained childInfo array, and the UI sums one level from there.
+    const { client } = createHarness({
+      issues: [baseIssue({
+        estimation: 2,
+        reportedTime: 0.5,
+        subIssues: 2,
+        childInfo: [
+          { childId: 'kid-1', estimation: 3, reportedTime: 1.5 },
+          { childId: 'kid-2', estimation: '4', reportedTime: '2' }
+        ]
+      })]
+    });
+
+    const page = await client.listIssues('PROJ', undefined, undefined, undefined, undefined, 10, undefined,
+      { fields: ['estimation', 'reportedTime', 'estimationTotal', 'reportedTimeTotal'] });
+
+    assert.deepEqual(page.items, [{
+      id: 'PROJ-1',
+      estimation: 2,
+      reportedTime: 0.5,
+      estimationTotal: 9,
+      reportedTimeTotal: 4
+    }]);
+  });
+
+  it('omits the rollup entirely for an issue with no children', async () => {
+    const { client } = createHarness({ issues: [baseIssue({ estimation: 2, reportedTime: 0.5 })] });
+
+    const page = await client.listIssues('PROJ', undefined, undefined, undefined, undefined, 10, undefined,
+      { fields: ['estimation', 'reportedTime', 'estimationTotal', 'reportedTimeTotal'] });
+
+    // A leaf must cost no extra bytes against the response budgets.
+    assert.deepEqual(page.items, [{ id: 'PROJ-1', estimation: 2, reportedTime: 0.5 }]);
+  });
+
   it('derives completedAt only from done-category statuses', async () => {
     const harness = createHarness();
     const readWith = async status => {

--- a/test/projectCreation.test.mjs
+++ b/test/projectCreation.test.mjs
@@ -171,8 +171,9 @@ describe('project type resolution', () => {
   });
 
   it('ignores HR and CRM types so their presence alone does not force the argument', async () => {
-    // The HMCP-33 report: a workspace with recruit and lead modules could not
-    // create a project at all without naming a type explicitly.
+    // A workspace with the recruit and lead modules enabled could not create a
+    // project at all without naming a type explicitly, because their vacancy
+    // and funnel types counted toward "multiple types found".
     const { client, calls } = createHarness({
       projectTypes: [
         { _id: 'recruit:template:DefaultVacancy', name: 'Default vacancy', tasks: ['tt-applicant'] },

--- a/test/timeNormalization.test.mjs
+++ b/test/timeNormalization.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { issueTimeFields, toHours } from '../src/helpers.mjs';
+import { issueTimeFields, issueRollupFields, toHours } from '../src/helpers.mjs';
 import { HulyClient } from '../src/client.mjs';
 
 process.env.HULY_URL ??= 'https://huly.example.test';
@@ -17,6 +17,29 @@ describe('time numeric normalization', () => {
       estimation: 4,
       reportedTime: 1.5
     });
+  });
+
+  it('rolls up childInfo one level and reports nothing for a leaf', () => {
+    assert.equal(issueRollupFields({ estimation: 1, reportedTime: 1 }), null,
+      'an issue with no childInfo has no rollup');
+    assert.equal(issueRollupFields({ childInfo: [] }), null, 'an empty childInfo is not a rollup');
+    assert.equal(issueRollupFields(undefined), null);
+
+    assert.deepEqual(
+      issueRollupFields({
+        estimation: 2,
+        reportedTime: 0.5,
+        childInfo: [
+          { childId: 'a', estimation: 3, reportedTime: 1.5 },
+          { childId: 'b', estimation: '4', reportedTime: '2' }
+        ]
+      }),
+      { estimationTotal: 9, reportedTimeTotal: 4 });
+
+    // A malformed stored value must not poison the total with NaN.
+    assert.deepEqual(
+      issueRollupFields({ estimation: 1, reportedTime: 1, childInfo: [{ childId: 'a', estimation: 'x' }] }),
+      { estimationTotal: 1, reportedTimeTotal: 1 });
   });
 
   it('logTime writes numeric report values and numeric issue totals', async () => {
@@ -64,8 +87,8 @@ describe('time numeric normalization', () => {
       issue: { _id: 'issue-id', reportedTime: 0 }
     });
 
-    // Each of these coerced to 0 before HMCP-67: the tool reported success
-    // while the workspace recorded no time at all.
+    // Each of these once coerced to 0: the tool reported success while the
+    // workspace recorded no time at all.
     for (const bad of ['two', '', null, undefined, true, NaN, Infinity, {}]) {
       await assert.rejects(
         () => client.logTime('PROJ-1', bad, 'work'),


### PR DESCRIPTION
An issue's `estimation` and `reportedTime` count only what is booked directly on it. Huly never rolls descendants into those fields, so a parent issue read through this server appeared to have no time at all, while the Huly UI showed a total for the same issue.

## Where the rollup actually lives

The per-child totals are kept in the parent's `childInfo` array, and **the server maintains it**. Verified by changing a child's estimation through `update_issue`, which writes only the child document, and observing the parent's `childInfo` entry follow — then revert. Nothing in this server writes to the parent.

So the gap was never a lost write. It was that the read paths returned the raw stored field and ignored the rollup sitting on the same document.

## What changed

`get_issue` and `list_issues` now also return `estimationTotal` and `reportedTimeTotal` for an issue that has children, summed from `childInfo`.

The rollup is **one level deep**, because that is what the UI does: a grandchild's time reaches a grandparent only through its parent's direct total. Matching the UI keeps both surfaces reporting the same number instead of inventing a third.

## Compatibility

- `estimation` and `reportedTime` keep their existing meaning — no field is redefined, so current parsers are unaffected.
- An issue with no children emits neither new field, so response sizes are unchanged for every leaf.
- Both fields are projectable through `fields`, registered in `ISSUE_BASE_FIELDS` so the tool schema advertises them automatically.
- `summarize_project` already totals direct values and needs no change; totalling the rolled-up values there would double-count parents against their children.

## Verification

- 3 new tests: rollup arithmetic including malformed stored values that must not poison a total with `NaN`, list projection for an issue with children, and a leaf asserting both fields are absent.
- 512 unit tests pass, lint and markdown lint clean.
- Verified against live data: a parent with eight children returns totals matching the figures the Huly UI displays for the same issues, and a leaf returns neither field.

Test comments in the touched files now describe the behaviour they guard rather than citing an external tracker.